### PR TITLE
fix #875: DirectorySource.LoadArtifactByName should correctly match duplicate file names

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -412,5 +412,70 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-   }
+        // LoadByName should handle duplicate filenames in (different subfolders of) the contentdirectory
+        // https://github.com/ewoutkramer/fhir-net-api/issues/875
+
+        [TestMethod]
+        public void OpenDuplicateFileNames()
+        {
+            var testPath = prepareExampleDirectory(out int numFiles);
+
+            // Additional temporary folder without read permissions
+            const string subFolderName = "sub";
+            var fullSubFolderPath = Path.Combine(testPath, subFolderName);
+            Directory.CreateDirectory(fullSubFolderPath);
+
+            string srcPath = Path.Combine("TestData", "snapshot-test", "WMR");
+            const string srcFile = "MyBasic.structuredefinition.xml";
+
+            // Create duplicate files in content directory and subfolder
+            copy(srcPath, srcFile, testPath);
+            copy(srcPath, srcFile, fullSubFolderPath);
+
+            var dirSource = new DirectorySource(testPath, new DirectorySourceSettings() { IncludeSubDirectories = true });
+
+            Resource OpenStream(string filePath)
+            {
+                using (var stream = dirSource.LoadArtifactByName(filePath))
+                {
+                    return new FhirXmlParser().Parse<Resource>(SerializationUtil.XmlReaderFromStream(stream));
+                }
+            }
+
+            // Retrieve artifacts by full path
+
+            var rootFilePath = Path.Combine(testPath, srcFile);
+            Assert.IsTrue(File.Exists(rootFilePath));
+            var res = OpenStream(rootFilePath);
+            Assert.IsNotNull(res);
+            // Modify the resource id and save back
+            var dupId = res.Id;
+            var rootId = Guid.NewGuid().ToString();
+            res.Id = rootId;
+            var xml = new FhirXmlSerializer().SerializeToString(res);
+
+            var dupFilePath = Path.Combine(fullSubFolderPath, srcFile);
+            Assert.IsTrue(File.Exists(dupFilePath));
+            res = OpenStream(dupFilePath);
+            Assert.IsNotNull(res);
+            // Verify that we received the duplicate file from subfolder,
+            // not the modified file in the root content directory
+            Assert.AreEqual(dupId, res.Id);
+            Assert.AreNotEqual(rootId, res.Id);
+
+            // Retrieve artifact by file name
+            // Should return nearest match, i.e. from content directory
+            res = OpenStream(srcFile);
+            Assert.IsNotNull(res);
+            Assert.AreEqual(dupId, res.Id);
+
+            // Retrieve artifact by relative path
+            // Should return duplicate from subfolder
+            var relPath = Path.Combine(subFolderName, srcFile);
+            res = OpenStream(relPath);
+            Assert.IsNotNull(res);
+            Assert.AreEqual(dupId, res.Id);
+        }
+
+    }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/DirectorySource.cs
@@ -484,11 +484,42 @@ namespace Hl7.Fhir.Specification.Source
         /// Also accepts relative file paths.
         /// </summary>
         /// <exception cref="InvalidOperationException">More than one file exists with the specified name.</exception>
-        public Stream LoadArtifactByName(string name)
+        public Stream LoadArtifactByName(string filePath)
         {
-            if (name == null) throw Error.ArgumentNull(nameof(name));
-            var fullFileName = GetFilePaths().SingleOrDefault(path => path.EndsWith(Path.DirectorySeparatorChar + name, PathComparison));
-            return fullFileName == null ? null : File.OpenRead(fullFileName);
+            if (filePath == null) throw Error.ArgumentNull(nameof(filePath));
+
+
+            // [WMR 20190219] https://github.com/ewoutkramer/fhir-net-api/issues/875
+            // var fullFileName = GetFilePaths().SingleOrDefault(path => path.EndsWith(Path.DirectorySeparatorChar + filePath, PathComparison));
+            //return fullFileName == null ? null : File.OpenRead(fullFileName);
+
+            // Exact match on absolute path, or partial match on relative path
+            bool isMatch(ArtifactSummary summary)
+                => PathComparer.Equals(summary.Origin, filePath)
+                || summary.Origin.EndsWith(Path.DirectorySeparatorChar + filePath, PathComparison);
+
+            // Only consider valid summaries for recognized artifacts
+            bool isCandidateArtifact(ArtifactSummary summary)
+                => !(summary is null)
+                && !summary.IsFaulted
+                && !(summary.Origin is null)
+                && isMatch(summary);
+
+            var candidates = GetSummaries().Where(isCandidateArtifact);
+
+            // We might match multiple files; pick best/nearest fit
+            ArtifactSummary match = null;
+            foreach (var candidate in candidates)
+            {
+                if (match is null || candidate.Origin.Length < match.Origin.Length)
+                {
+                    match = candidate;
+                }
+            }
+
+            if (match?.Origin is null) { return null; }
+
+            return File.OpenRead(match.Origin);
         }
 
         #endregion


### PR DESCRIPTION
Fix for issue #875