### PR TITLE
fix: #904 ArtifactSummary should indicate Bundle entries

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
@@ -1,4 +1,4 @@
-﻿using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Source;
@@ -45,6 +45,7 @@ namespace Hl7.Fhir.Specification.Tests
             harvesters[ArtifactSummaryGenerator.ConformanceHarvesters.Length] = HarvestPatientSummary;
 
             var summary = assertSummary(path, harvesters);
+            Assert.IsFalse(summary.IsBundleEntry);
             Assert.AreEqual(ResourceType.Patient.GetLiteral(), summary.ResourceTypeName);
             var familyNames = summary.GetValueOrDefault<string[]>(PatientFamilyNameKey);
             Assert.IsNotNull(familyNames);
@@ -72,6 +73,7 @@ namespace Hl7.Fhir.Specification.Tests
             var summary = assertSummary(path);
 
             // Common properties
+            Assert.IsFalse(summary.IsBundleEntry);
             Assert.AreEqual(ResourceType.ValueSet.GetLiteral(), summary.ResourceTypeName);
             Assert.IsTrue(summary.ResourceType == ResourceType.ValueSet);
 
@@ -90,6 +92,7 @@ namespace Hl7.Fhir.Specification.Tests
             const string url = @"http://hl7.org/fhir/StructureDefinition/patient-religion";
             var summary = assertSummary(path);
             // Common properties
+            Assert.IsFalse(summary.IsBundleEntry);
             Assert.AreEqual(ResourceType.StructureDefinition.GetLiteral(), summary.ResourceTypeName);
             Assert.IsTrue(summary.ResourceType == ResourceType.StructureDefinition);
             // Conformance resource properties
@@ -120,6 +123,7 @@ namespace Hl7.Fhir.Specification.Tests
 
                 // Common properties
                 Assert.AreEqual(path, summary.Origin);
+                Assert.IsTrue(summary.IsBundleEntry);
 
                 var fi = new FileInfo(path);
                 Assert.AreEqual(fi.Length, summary.FileSize);
@@ -178,6 +182,7 @@ namespace Hl7.Fhir.Specification.Tests
 
                 // Common properties
                 Assert.AreEqual(path, summary.Origin);
+                Assert.IsTrue(summary.IsBundleEntry);
 
                 var fi = new FileInfo(path);
                 Assert.AreEqual(fi.Length, summary.FileSize);

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummary.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummary.cs
@@ -135,6 +135,9 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>The <see cref="DirectorySource"/> generates virtual uri values for resources that are not bundle entries.</remarks>
         public string ResourceUri => properties.GetResourceUri();
 
+        /// <summary>Returns <c>true</c> if the summary describes a Bundle entry resource.</summary>
+        public bool IsBundleEntry => properties.IsBundleEntry();
+
         #endregion
 
         #region IEnumerable

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryGenerator.cs
@@ -288,6 +288,7 @@ namespace Hl7.Fhir.Specification.Summary
                             properties.SetPosition(navStream.Position);
                             properties.SetTypeName(current.GetResourceTypeIndicator());
                             properties.SetResourceUri(navStream.Position);
+                            properties.SetIsBundleEntry(navStream.IsBundle);
 
                             // Allow caller to modify/enrich harvested properties
                             customPropertyInitializer?.Invoke(properties);

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryHarvesters.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryHarvesters.cs
@@ -39,6 +39,7 @@ namespace Hl7.Fhir.Specification.Source
         public static readonly string PositionKey = "Position";
         public static readonly string TypeNameKey = "TypeName";
         public static readonly string ResourceUriKey = "Uri";
+        public static readonly string IsBundleEntryKey = "IsBundleEntry";
 
         /// <summary>Try to retrieve the property value for the specified key.</summary>
         /// <param name="properties">An artifact summary property bag.</param>
@@ -121,6 +122,15 @@ namespace Hl7.Fhir.Specification.Source
         internal static void SetResourceUri(this ArtifactSummaryPropertyBag properties, string value)
         {
             properties[ResourceUriKey] = value;
+        }
+
+        /// <summary>Returns <c>true</c> if the summary describes a Bundle entry.</summary>
+        public static bool IsBundleEntry(this IArtifactSummaryPropertyBag properties)
+            => properties.GetValueOrDefault(IsBundleEntryKey) is bool b ? b : false;
+
+        internal static void SetIsBundleEntry(this ArtifactSummaryPropertyBag properties, bool value)
+        {
+            properties[IsBundleEntryKey] = value;
         }
     }
 


### PR DESCRIPTION
Implement ArtifactSummary.IsBundleEntry property, initialize value from INavigatorStream.IsBundle property.