### PR TITLE
#896 Fixed the IsRequired check. Added unit test for it.

### DIFF
--- a/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
@@ -1,5 +1,6 @@
 ﻿using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Specification;
+using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace Hl7.Fhir.Serialization.Tests
     {
         public ITypedElement getXmlNode(string xml, FhirXmlParsingSettings s = null) =>
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
-
+        
         [TestMethod]
         public void Summary()
         {
@@ -56,6 +57,21 @@ namespace Hl7.Fhir.Serialization.Tests
 
             var maskedChildren = masker.Descendants().Count();
             Assert.AreEqual(nav.Descendants().Count()-3 , maskedChildren);
-        }       
+        }
+
+        [TestMethod]
+        public void SummaryCountUsingStructureDefinitionSummaryProvider()
+        {
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "mask-text.xml"));
+
+            var nav = new ScopedNode(getXmlNodeSDSP(tpXml));
+            var masker = MaskingNode.ForCount(nav);
+
+            var maskedChildren = masker.Descendants().Count();
+            Assert.AreEqual(maskedChildren, 2);
+
+            ITypedElement getXmlNodeSDSP(string xml, FhirXmlParsingSettings s = null) =>
+                XmlParsingHelpers.ParseToTypedElement(xml, new StructureDefinitionSummaryProvider(ZipSource.CreateValidationSource()), s);
+        }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -188,7 +188,7 @@ namespace Hl7.Fhir.Specification
 
         public bool InSummary => _definition.IsSummary ?? false;
 
-        public bool IsRequired => (_definition.Min ?? 0) > 1;
+        public bool IsRequired => (_definition.Min ?? 0) >= 1;
 
         public XmlRepresentation Representation
         {


### PR DESCRIPTION
All our tests were covering the parsing with PocoStructureDefinitionSummaryProvider. Added another test that uses StructureDefinitionSummaryProvider. This was also the case where Christiaan found the issue.