### PR TITLE
fix: #889 Additional rules will get confused by hybrid typed trees

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
@@ -371,7 +371,8 @@ namespace Hl7.Fhir.Serialization
             object checkOrder(ITypedElement node, IExceptionSource ies, object state)
             {
                 var sdSummary = node.Definition;
-                if (sdSummary == null) return null;
+                var serializationDetails = node.GetXmlSerializationDetails();
+                if (sdSummary == null || serializationDetails == null) return null;
 
                 if (state is OrderRuleState ors)
                 {


### PR DESCRIPTION
#889 Extra check added in order to skip the order validation for a node that was not part of the initial source tree read from a xml file.
