### PR TITLE
Changes from DSTU2 to STU3 (forward merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-|DSTU2|STU3|Released|
+|STU3|R4|Released|
 |---|---|---|
-|[![Build status](https://dev.azure.com/firely/fhir-net-api/_apis/build/status/Continuous%20Build?branchName=develop)](https://dev.azure.com/firely/fhir-net-api/_build?view=buildsHistory&definitionId=14)|[![Build status](https://dev.azure.com/firely/fhir-net-api/_apis/build/status/Continuous%20Build?branchName=develop-stu3)](https://dev.azure.com/firely/fhir-net-api/_build?view=buildsHistory&definitionId=14)|[![Release status](https://vsrm.dev.azure.com/firely/_apis/public/Release/badge/d27985be-1c61-41fd-82e7-23e7a2f06dc3/1/2)](https://dev.azure.com/firely/fhir-net-api/_releaseDefinition?definitionId=1&_a=definition-pipeline)|
+|[![Build status](https://dev.azure.com/firely/fhir-net-api/_apis/build/status/Continuous%20Build?branchName=develop-stu3)](https://dev.azure.com/firely/fhir-net-api/_build?view=buildsHistory&definitionId=14)|[![Build status](https://dev.azure.com/firely/fhir-net-api/_apis/build/status/Continuous%20Build?branchName=develop-r4)](https://dev.azure.com/firely/fhir-net-api/_build?view=buildsHistory&definitionId=14)|[![Release status](https://vsrm.dev.azure.com/firely/_apis/public/Release/badge/d27985be-1c61-41fd-82e7-23e7a2f06dc3/1/2)](https://dev.azure.com/firely/fhir-net-api/_releaseDefinition?definitionId=1&_a=definition-pipeline)|
 
 ## Introduction ##
 This is the official support API for working with [HL7 FHIR][fhir-spec] on the Microsoft .NET (dotnet) platform.
 
+## Release notes ##
+Read the releases notes and the documentation on [simplifier](http://docs.simplifier.net/fhirnetapi/releasenotes.html)
+
+## What's in the box?
 This library provides:
 * Class models for working with the FHIR data model using POCO's
 * Xml and Json parsers and serializers
@@ -26,8 +30,7 @@ each with breaking changes - so you need to ensure you use the version that is r
 * [DSTU1][dstu1-spec] (published September 2014) is mostly obsolete, and the .NET version for this publication is not maintained anymore.
 * [DSTU2][dstu2-spec] (published October 2015) in widespread use, and still supported by this library and other tooling on the market.
 * [STU3][stu3-spec] (published March 2017) latest release, mature support by this library and most other tooling on the market.
-* [R4][r4-spec] (not yet published), support in alpha by this library. Would not be supported by production systems, since this release is still in development. Expected publication in Q3 2018.
-
+* [R4][r4-spec] (published January 2019), support in alpha by this library. Would not be supported by production systems, since this release is still in development.
 
 Planned release DSTU2.1 was never published by HL7, but you will still find traces of it, in particular we still keep the NuGet package for it available.
 

--- a/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
@@ -373,7 +373,8 @@ namespace Hl7.Fhir.Serialization
                 if (PermissiveParsing) return null;
 
                 var sdSummary = node.Definition;
-                if (sdSummary == null) return null;
+                var serializationDetails = node.GetXmlSerializationDetails();
+                if (sdSummary == null || serializationDetails == null) return null;
 
                 if (state is OrderRuleState ors)
                 {


### PR DESCRIPTION
This is the last forward merge from develop to develop-stu3. 

Because we will not develop anymore on DSTU2, the develop branch will be frozen. Only urgent hotfixes are allow on this branch (develop).