### PR TITLE
feature: allow FunctionCallExpressions without focus.

### DIFF
--- a/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/ExpressionNode.cs
@@ -107,7 +107,6 @@ namespace Hl7.FhirPath.Expressions
 
         public FunctionCallExpression(Expression focus, string name, TypeInfo type, IEnumerable<Expression> arguments) : base(type)
         {
-            if (focus == null) throw Error.ArgumentNull("focus");
             if (String.IsNullOrEmpty(name)) throw Error.ArgumentNull("name");
             if (arguments == null) throw Error.ArgumentNull("arguments");
 


### PR DESCRIPTION
To support the mapping language, we no longer require a function call invocation to depend on a focus (which was true for FhirPath expressions).