### PR TITLE
Wrong usage of Setting parameter in buildNodeSettings

### DIFF
--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
@@ -26,12 +26,12 @@ namespace Hl7.Fhir.Serialization
 
         public T Parse<T>(JsonReader reader) where T : Base => (T)Parse(reader, typeof(T));
         
-        private FhirJsonParsingSettings buildNodeSettings(ParserSettings settings) =>
+        private static FhirJsonParsingSettings buildNodeSettings(ParserSettings settings) =>
                 new FhirJsonParsingSettings
                 {
                     // TODO: True for DSTU2, should be false in STU3
                     AllowJsonComments = false,
-                    PermissiveParsing = Settings.PermissiveParsing
+                    PermissiveParsing = settings.PermissiveParsing
                 };
 
         public Base Parse(string json, Type dataType = null)

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
@@ -24,11 +24,11 @@ namespace Hl7.Fhir.Serialization
 
         public T Parse<T>(string xml) where T : Base => (T)Parse(xml, typeof(T));
         
-        private FhirXmlParsingSettings buildNodeSettings(ParserSettings settings) =>
+        private static FhirXmlParsingSettings buildNodeSettings(ParserSettings settings) =>
                 new FhirXmlParsingSettings
                 {
-                    DisallowSchemaLocation = Settings.DisallowXsiAttributesOnRoot,
-                    PermissiveParsing = Settings.PermissiveParsing
+                    DisallowSchemaLocation = settings.DisallowXsiAttributesOnRoot,
+                    PermissiveParsing = settings.PermissiveParsing
                 };
 
         public Base Parse(string xml, Type dataType = null)


### PR DESCRIPTION
#941
Fixed the buildNodeSettings methods to use the parameter instead of the global variable.
