### PR TITLE
Fix: #952 - DirectorySource.Summaries - ignore unknown file extensions (2nd attempt)

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSummaryTests.cs
@@ -343,6 +343,25 @@ namespace Hl7.Fhir.Specification.Tests
 
         }
 
+        [TestMethod]
+        public void TestListSummariesWithExcludeFilter()
+        {
+            string path = "TestData";
+
+            var dirSource = new DirectorySource(path, new DirectorySourceSettings()
+            {
+                IncludeSubDirectories = true,
+                Excludes = new string[] { "/snapshot-test/", "/validation/", "/grahame-validation-examples/", "*.zip" }
+            });
+
+            var summaries = dirSource.ListSummaries().ToList();
+            Assert.IsNotNull(summaries);
+
+            // Verify invalid files in folder 'grahame-validation-examples' are excluded
+            var errors = dirSource.ListSummaryErrors().ToList();
+            Assert.AreEqual(0, errors.Count);
+        }
+        
         // [WMR 20190305] Belongs to pull request #890
         [TestMethod, Ignore]
         public void TestSummarizeAnonymousResources()
@@ -412,24 +431,6 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.IsNotNull(summary.LastModified);
             }
         }
-     
-        public void TestListSummariesWithExcludeFilter()
-        {
-            string path = "TestData";
 
-            var dirSource = new DirectorySource(path, new DirectorySourceSettings()
-            { 
-                IncludeSubDirectories = true,
-                Excludes = new string[] { "/snapshot-test/", "/validation/", "/grahame-validation-examples/"},
-                Masks = new string[] { "*.json", "*.xml", "*.sch" }
-            });
-
-            var summaries = dirSource.ListSummaries().ToList();
-            Assert.IsNotNull(summaries);
-
-            // Verify invalid files in folder 'grahame-validation-examples' are excluded
-            var errors = dirSource.ListSummaryErrors().ToList();
-            Assert.AreEqual(0, errors.Count);
-        }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryGenerator.cs
@@ -388,7 +388,7 @@ namespace Hl7.Fhir.Specification.Summary
                 // ConfigurableNavigatorStreamFactory returns null for unknown file extensions
                 // No need to call DefaultNavigatorStreamFactory (redundant)
                 navStream = navigatorStreamFactory?.Invoke(fi.FullName);
-                // ?? DefaultNavigatorStreamFactory.Create(fi.FullName);
+                    // ?? DefaultNavigatorStreamFactory.Create(fi.FullName);
 
                 result = Generate(navStream, InitializeSummaryFromOrigin, harvesters);
             }


### PR DESCRIPTION
New pull request based on develop-stu3, ready for porting to develop-r4.
Replaces the original pull request #954 for develop-r4 (broken, obsolete).