### PR TITLE
Validation enhancements

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/xUnitBug.cs
+++ b/src/Hl7.Fhir.Specification.Tests/xUnitBug.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Hl7.Fhir.Core.Tests
+namespace Hl7.Fhir.Specification.Tests
 {
     public class xUnitBug
     {

--- a/src/Hl7.Fhir.Specification/Schema/Binding.cs
+++ b/src/Hl7.Fhir.Specification/Schema/Binding.cs
@@ -79,7 +79,7 @@ namespace Hl7.Fhir.Specification.Schema
             if (!ModelInfo.IsBindable(input.InstanceType))
             {
                 return Issue.CONTENT_TYPE_NOT_BINDEABLE 
-                    .NewOutcomeWithIssue("Validation of binding with non-bindable instance type '{input.InstanceType}' always succeeds.", input);
+                    .NewOutcomeWithIssue($"Validation of binding with non-bindable instance type '{input.InstanceType}' always succeeds.", input);
             }
 
             var bindable = parseBindable(input);

--- a/src/Hl7.Fhir.Specification/Support/Issue.cs
+++ b/src/Hl7.Fhir.Specification/Support/Issue.cs
@@ -58,10 +58,10 @@ namespace Hl7.Fhir.Support
             Type = type;
         }
         /// <summary>Factory method.</summary>
-        internal static Issue Create(int code, OperationOutcome.IssueSeverity severity, OperationOutcome.IssueType type) =>
+        public static Issue Create(int code, OperationOutcome.IssueSeverity severity, OperationOutcome.IssueType type) =>
             new Issue(code, severity, type);
 
-        // Validation resouce instance errors
+        // Validation resource instance errors
         public static readonly Issue CONTENT_ELEMENT_MUST_HAVE_VALUE_OR_CHILDREN = Create(1000, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_ELEMENT_HAS_UNKNOWN_CHILDREN = Create(1001, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_ELEMENT_HAS_INCORRECT_TYPE = Create(1003, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
@@ -72,8 +72,8 @@ namespace Hl7.Fhir.Support
         public static readonly Issue CONTENT_DOES_NOT_MATCH_PATTERN_VALUE = Create(1009, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_ELEMENT_CANNOT_DETERMINE_TYPE = Create(1010, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE = Create(1011, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
-        public static readonly Issue CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT = Create(1012, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
-        public static readonly Issue CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT = Create(1013, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT = Create(1012, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invariant);
+        public static readonly Issue CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT = Create(1013, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invariant);
         public static readonly Issue CONTENT_REFERENCE_OF_INVALID_KIND = Create(1015, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_CONTAINED_REFERENCE_NOT_RESOLVABLE = Create(1016, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_UNPARSEABLE_REFERENCE = Create(1017, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Validation
 
     internal static class FpConstraintValidationExtensions
     {
-        public static OperationOutcome ValidateFp(this Validator v, ElementDefinition definition, ScopedNode instance)
+        public static OperationOutcome ValidateFp(this Validator v, string structureDefinitionUrl, ElementDefinition definition, ScopedNode instance)
         {
             var outcome = new OperationOutcome();
 
@@ -55,7 +55,18 @@ namespace Hl7.Fhir.Validation
                     var issue = constraintElement.Severity == ElementDefinition.ConstraintSeverity.Error ?
                         Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT : Issue.CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT;
 
-                    v.Trace(outcome, text, issue, instance);
+                    // just use the constraint description in the error message, as this is to explain the issue
+                    // to a human, the code for the error should be in the coding
+                    var outcomeIssue = new OperationOutcome.IssueComponent()
+                    {
+                        Severity = issue.Severity,
+                        Code = issue.Type,
+                        Details = issue.ToCodeableConcept(text),
+                        Diagnostics = constraintElement.GetFhirPathConstraint(), // Putting the fhirpath expression of the invariant in the diagnostics
+                        Location = new string[] { instance.Location }
+                    };
+                    outcomeIssue.Details.Coding.Add(new Coding(structureDefinitionUrl, constraintElement.Key, constraintElement.Human));
+                    outcome.AddIssue(outcomeIssue);
                 }
             }
 

--- a/src/Hl7.Fhir.Specification/Validation/SliceBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/SliceBucket.cs
@@ -24,9 +24,10 @@ namespace Hl7.Fhir.Validation
         {
             // TODO: Should check whether the discriminator is a valid child path of root. Wait until we have the
             // definition walker, which would walk across references if necessary.
+            // TODO: Brian I think Pattern is actually supported too
             foreach (var d in discriminator)
             {
-                if (d.Type != ElementDefinition.DiscriminatorType.Value)
+                if (d.Type != ElementDefinition.DiscriminatorType.Value && d.Type != ElementDefinition.DiscriminatorType.Pattern)
                     throw Error.NotImplemented($"Slicing with a discriminator of type '{d.Type}' is not yet supported by this validator.");
             }
 

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -275,7 +275,7 @@ namespace Hl7.Fhir.Validation
             outcome.Add(this.ValidatePattern(elementConstraints, instance));
             outcome.Add(this.ValidateMinMaxValue(elementConstraints, instance));
             outcome.Add(ValidateMaxLength(elementConstraints, instance));
-            outcome.Add(this.ValidateFp(elementConstraints, instance));
+            outcome.Add(this.ValidateFp(definition.StructureDefinition.Url, elementConstraints, instance));
             outcome.Add(this.ValidateExtension(elementConstraints, instance, "http://hl7.org/fhir/StructureDefinition/regex"));
 
             // new style validator - has a configure and then execute step.

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -349,6 +349,8 @@ namespace Hl7.Fhir.Validation
                     symbolTable.AddFhirExtensions();
 
                     _fpCompiler = new FhirPathCompiler(symbolTable);
+
+                    Settings.FhirPathCompiler = _fpCompiler;
                 }
 
                 return _fpCompiler;


### PR DESCRIPTION
#992 Validation updates & minor bug fixes.

* Make the Issue.Create method public so that other systems may use this code to generate their own error messages using this infrastructure (including injecting their own Issues into the outcomes)
* The Constraint errors are on invariants, and so should use that issue type rather than just "invalid"
* Validation by Pattern also works - is same as by value with this implementation