### PR TITLE
_sort did not allow the use of underscore search parameter such as '_lastUpdated'

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
@@ -238,6 +238,21 @@ namespace Hl7.Fhir.Test.Rest
         }
 
         [TestMethod]
+        public void ParseAndSerializeSortParams()
+        {
+            var q = new SearchParams();
+      
+            q.Add("_sort", "-sorted,sorted2,_lastUpdated");
+      
+            var output = q.ToUriParamList().ToQueryString();
+            Assert.AreEqual("_sort=-sorted%2Csorted2%2C_lastUpdated", output);
+
+            var q2 = SearchParams.FromUriParamList(UriParamList.FromQueryString(output));
+            Assert.AreEqual(q.Query, q2.Query);     
+            CollectionAssert.AreEquivalent(q.Sort.ToList(), q2.Sort.ToList()); 
+        }
+
+        [TestMethod]
         public void AcceptEmptyGenericParam()
         {
             var q = new SearchParams();

--- a/src/Hl7.Fhir.Core/Rest/SearchParams.cs
+++ b/src/Hl7.Fhir.Core/Rest/SearchParams.cs
@@ -128,7 +128,7 @@ namespace Hl7.Fhir.Rest
                 var elements = value.Split(',');
                 if (elements.Any(f => String.IsNullOrEmpty(f)))
                     throw Error.Format($"Invalid {SEARCH_PARAM_SORT}: must be a list of non-empty element names");
-                if (!elements.All(f => Char.IsLetter(f[0]) || f[0] == '-' ))
+                if (!elements.All(f => Char.IsLetter(f[0]) || f[0] == '-' || f[0] == '_'))
                     throw Error.Format($"Invalid {SEARCH_PARAM_SORT}: must be a list of element names, optionally prefixed with '-'");
 
                 addNonEmptySort(elements);


### PR DESCRIPTION
When using the '_sort' search result parameter to order the returned results there was a bug in the API in that it checked that values of the _sort must begin with a character that is either a letter or '-' for decreasing order. However, this rule neglected the case where the search parameter being used to sort was one of the 'Parameters for all resources' which all begin with an underscore character '_'. The prime example of this would be '[base]/Patient?_sort=_lastUpdated'

This commit adds support for underscore and a new test case.
