### PR TITLE
ElementNode CreateList Overload and code comments

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/PocoNavigatorTests.cs
@@ -28,10 +28,10 @@ namespace Hl7.Fhir
             {
                 if (f is IEnumerable<ITypedElement>)
                 {
-                    object[] bits = (f as IEnumerable<ITypedElement>).Select(i =>
+                    var bits = (f as IEnumerable<ITypedElement>).Select(i =>
                     {
                         return i is PocoElementNode ? (i as PocoElementNode).ShortPath : "?";
-                    }).ToArray();
+                    });
                     return ElementNode.CreateList(bits);
                 }
                 return ElementNode.CreateList("?");

--- a/src/Hl7.Fhir.ElementModel/ElementNode.cs
+++ b/src/Hl7.Fhir.ElementModel/ElementNode.cs
@@ -26,7 +26,22 @@ namespace Hl7.Fhir.ElementModel
         /// <returns></returns>
         public static ITypedElement ForPrimitive(object value) => new PrimitiveElement(value);
 
+        /// <summary>
+        /// Create a fixed length set of values (but also support variable number of parameter values)
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
         public static IEnumerable<ITypedElement> CreateList(params object[] values) => values != null
+                ? values.Select(value => value == null ? null : value is ITypedElement ? (ITypedElement)value : ForPrimitive(value))
+                : EmptyList;
+
+        /// <summary>
+        /// Create a variable list of values using an enumeration
+        /// - so doesn't have to be converted to an array in memory (issue with larger dynamic lists)
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static IEnumerable<ITypedElement> CreateList(IEnumerable<object> values) => values != null
                 ? values.Select(value => value == null ? null : value is ITypedElement ? (ITypedElement)value : ForPrimitive(value))
                 : EmptyList;
 

--- a/src/Hl7.Fhir.ElementModel/IShortPathGenerator.cs
+++ b/src/Hl7.Fhir.ElementModel/IShortPathGenerator.cs
@@ -26,6 +26,7 @@ namespace Hl7.Fhir.ElementModel
     {
         /// <summary>
         /// Gets the short path of the node the <see cref="ITypedElement"/> represents.
+        /// (any single cardinality nodes will be stripped of their [0] array indexer)
         /// </summary>
         /// <value>Returns the short path, which is a dotted path notation to the node</value>
         string ShortPath { get; }


### PR DESCRIPTION
Include an alternative implementation of CreateList that takes an IEnumerable list, rather than an array. This way you don't need to convert it to an array, which could be expensive in larger lists

Add a code comment for the shortpath generator that indicates what is different. (to help with coding)
