### PR TITLE
#Fix for Issue 1002

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Validation/ValidationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Validation/ValidationTests.cs
@@ -166,12 +166,6 @@ namespace Hl7.Fhir.Tests.Validation
 
             patn.Contained = null;
             DotNetAttributeValidation.Validate(pat);
-
-            patn.Text = new Narrative();
-            patn.Text.Div = "<div>Narrative in contained resource</div>";
-
-            // Contained resources should not contain narrative
-            validateErrorOrFail(pat);
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core/Model/DomainResource.cs
+++ b/src/Hl7.Fhir.Core/Model/DomainResource.cs
@@ -50,9 +50,6 @@ namespace Hl7.Fhir.Model
 
             if (this.Contained != null)
             {
-                if (!Contained.OfType<DomainResource>().All(dr => dr.Text == null))
-                    result.Add(new ValidationResult("Resource has contained resources with narrative"));
-
                 if (!Contained.OfType<DomainResource>().All(cr => cr.Contained == null || !cr.Contained.Any()))
                     result.Add(new ValidationResult("Resource has contained resources with nested contained resources"));
             }


### PR DESCRIPTION
https://github.com/FirelyTeam/fhir-net-api/issues/1002

Changes:
 * Remove the validation for the contained resource with Text
 * Fixed a unit test which was validating the old behaviour

Note: There are 13 failing unit tests at this point. There were 13 failing prior to my change, so i have assumed these are not regression that ive cause by my edits.

Please make sure you always reference the issue number this PR is related to.

If not related to an existing issue, include a description of the bug or feature this PRs is about.

Make sure you include unit tests for the code you are requesting us to pull.
