### PR TITLE
Empty line at the end of json and xml outputs

### DIFF
--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
@@ -21,7 +21,7 @@ namespace Hl7.Fhir.Serialization
         }
 
         private FhirJsonSerializationSettings buildFhirJsonWriterSettings() =>
-            new FhirJsonSerializationSettings { Pretty = Settings.Pretty };
+            new FhirJsonSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) => 
             MakeElementStack(instance, summary, elements).ToJson(buildFhirJsonWriterSettings());

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Serialization
         }
 
         private FhirXmlSerializationSettings buildFhirXmlWriterSettings() =>
-            new FhirXmlSerializationSettings { Pretty = Settings.Pretty };
+            new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) => 
             MakeElementStack(instance, summary, elements)

--- a/src/Hl7.Fhir.Core/Serialization/SerializerSettings.cs
+++ b/src/Hl7.Fhir.Core/Serialization/SerializerSettings.cs
@@ -19,6 +19,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool Pretty { get; set; } // = false;
 
+        /// <summary>
+        /// Add new line at the end of the serialized xml or json output.
+        /// </summary>
+        public bool AppendNewLine { get; set; } // = false;
+
         /// <summary>Default constructor. Creates a new <see cref="SerializerSettings"/> instance with default property values.</summary>
         public SerializerSettings() { }
 
@@ -38,6 +43,7 @@ namespace Hl7.Fhir.Serialization
             if (other == null) throw Error.ArgumentNull(nameof(other));
 
             other.Pretty = Pretty;
+            other.AppendNewLine = AppendNewLine;
         }
 
         /// <summary>Creates a new <see cref="SerializerSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
@@ -74,8 +74,30 @@ namespace Hl7.Fhir.Serialization.Tests
             var p = (new FhirJsonParser()).Parse<Patient>(json);
             output = (new FhirJsonSerializer(new SerializerSettings { Pretty = false })).SerializeToString(p);
             Assert.IsFalse(output.Substring(0, 20).Contains('\n'));
-            pretty = (new FhirJsonSerializer(new SerializerSettings { Pretty = true })).SerializeToString(p);
+            pretty = (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
             Assert.IsTrue(pretty.Substring(0, 20).Contains('\n'));
+        }
+
+        [TestMethod]
+        public void TestAppendNewLine()
+        {
+            var json = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+
+            var nav = getJsonElement(json);
+            var output = nav.ToJson();
+            Assert.IsFalse(output.Contains('\n'));
+            var pretty = nav.ToJson(new FhirJsonSerializationSettings { Pretty = true });
+            Assert.IsTrue(pretty.Contains('\n'));
+            var lastLine = pretty.Split('\n').Last();
+            Assert.IsFalse(string.IsNullOrEmpty(lastLine));
+
+            var p = (new FhirJsonParser()).Parse<Patient>(json);
+            output = (new FhirJsonSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToString(p);
+            lastLine = output.Split('\n').Last();
+            Assert.IsTrue(string.IsNullOrEmpty(lastLine));
+            pretty = (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
+            lastLine = pretty.Split('\n').Last();
+            Assert.IsTrue(string.IsNullOrEmpty(lastLine));
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -112,5 +112,26 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
         }
 
+        [TestMethod]
+        public void TestAppendNewLine()
+        {
+            var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
+
+            var nav = getXmlElement(xml);
+            var output = nav.ToXml();
+            Assert.IsFalse(output.Substring(0, 50).Contains('\n'));
+            var pretty = nav.ToXml(new FhirXmlSerializationSettings { Pretty = true });
+            Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
+            var lastLine = pretty.Split('\n').Last();
+            Assert.IsFalse(string.IsNullOrEmpty(lastLine));
+
+            var p = (new FhirXmlParser()).Parse<Patient>(xml);
+            output = (new FhirXmlSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToString(p);
+            lastLine = output.Split('\n').Last();
+            Assert.IsTrue(string.IsNullOrEmpty(lastLine));
+            pretty = (new FhirXmlSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
+            lastLine = pretty.Split('\n').Last();
+            Assert.IsTrue(string.IsNullOrEmpty(lastLine));
+        }
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
@@ -41,15 +41,15 @@ namespace Hl7.Fhir.Serialization
             source.ToTypedElement().WriteTo(destination, settings);
 #pragma warning restore 612, 618
         public static string ToJson(this ITypedElement source, FhirJsonSerializationSettings settings = null)
-            => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+            => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static string ToJson(this ISourceNode source, FhirJsonSerializationSettings settings = null)
-            => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+            => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
 #pragma warning disable 612, 618
         [Obsolete("Please consider switching to ITypedElement (which is what the new parsers return).")]
         public static string ToJson(this IElementNavigator source, FhirJsonSerializationSettings settings = null)
-              => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+              => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 #pragma warning restore 612, 618
 
         public static byte[] ToJsonBytes(this ITypedElement source, FhirJsonSerializationSettings settings = null)

--- a/src/Hl7.Fhir.Serialization/FhirJsonSerializationSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonSerializationSettings.cs
@@ -26,6 +26,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool Pretty { get; set; } // = false;
 
+        /// <summary>
+        /// Add new line at the end of the json output when converted to a string.
+        /// </summary>
+        public bool AppendNewLine { get; set; } // = false;
+
         /// <summary>Default constructor. Creates a new <see cref="FhirJsonSerializationSettings"/> instance with default property values.</summary>
         public FhirJsonSerializationSettings() {  }
 
@@ -46,6 +51,7 @@ namespace Hl7.Fhir.Serialization
 
             other.IgnoreUnknownElements = IgnoreUnknownElements;
             other.Pretty = Pretty;
+            other.AppendNewLine = AppendNewLine;
         }
 
         /// <summary>Creates a new <see cref="FhirJsonSerializationSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
@@ -42,14 +42,14 @@ namespace Hl7.Fhir.Serialization
 #pragma warning restore 612, 618
 
         public static string ToXml(this ISourceNode source, FhirXmlSerializationSettings settings = null)
-        => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+        => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static string ToXml(this ITypedElement source, FhirXmlSerializationSettings settings = null)
-                => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+                => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
 #pragma warning disable 612, 618
         public static string ToXml(this IElementNavigator source, FhirXmlSerializationSettings settings = null)
-        => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false);
+        => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 #pragma warning restore 612, 618
 
         public static byte[] ToXmlBytes(this ITypedElement source, FhirXmlSerializationSettings settings = null)

--- a/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlSerializationSettings.cs
@@ -39,6 +39,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool Pretty { get; set; } // = false;
 
+        /// <summary>
+        /// Add new line at the end of the xml output when converted to a string.
+        /// </summary>
+        public bool AppendNewLine { get; set; } // = false;
+
         /// <summary>Default constructor. Creates a new <see cref="FhirXmlSerializationSettings"/> instance with default property values.</summary>
         public FhirXmlSerializationSettings() { }
 
@@ -59,6 +64,7 @@ namespace Hl7.Fhir.Serialization
 
             other.IgnoreUnknownElements = IgnoreUnknownElements;
             other.Pretty = Pretty;
+            other.AppendNewLine = AppendNewLine;
         }
 
         /// <summary>Creates a new <see cref="FhirXmlSerializationSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
@@ -148,7 +148,7 @@ namespace Hl7.Fhir.Utility
             }
         }
 
-        public static string WriteXmlToString(Action<XmlWriter> serializer, bool pretty=false)
+        public static string WriteXmlToString(Action<XmlWriter> serializer, bool pretty=false, bool appendNewLine = false)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -164,7 +164,7 @@ namespace Hl7.Fhir.Utility
             {
                 serializer(xw);
                 xw.Flush();
-                return sb.ToString();
+                return appendNewLine ? sb.AppendLine().ToString() : sb.ToString();
             }
         }
 
@@ -181,7 +181,7 @@ namespace Hl7.Fhir.Utility
             return doc;
         }
 
-        public static string WriteJsonToString(Action<JsonWriter> serializer, bool pretty=false)
+        public static string WriteJsonToString(Action<JsonWriter> serializer, bool pretty = false, bool appendNewLine = false)
         {
             StringBuilder resultBuilder = new StringBuilder();
 
@@ -192,7 +192,7 @@ namespace Hl7.Fhir.Utility
                 jw.Formatting = pretty ? Newtonsoft.Json.Formatting.Indented : Newtonsoft.Json.Formatting.None;
                 serializer(jw);
                 jw.Flush();
-                return resultBuilder.ToString();
+                return appendNewLine ? resultBuilder.AppendLine().ToString() : resultBuilder.ToString();
             }
         }
 


### PR DESCRIPTION
#293 
Added new Setting for serializers to append new line at the end of json and xml outputs.
