### PR TITLE
Explicit exception when converting header string to datetime 

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/HttpToEntryExtensions.cs
@@ -46,7 +46,13 @@ namespace Hl7.Fhir.Rest
 
 #if NETSTANDARD1_1
             if (!String.IsNullOrEmpty(response.Headers[HttpUtil.LASTMODIFIED]))
-                    result.Response.LastModified = DateTimeOffset.Parse(response.Headers[HttpUtil.LASTMODIFIED]);
+            {
+                DateTimeOffset dateTimeOffset = new DateTimeOffset();
+                bool success = DateTimeOffset.TryParse(response.Headers[HttpUtil.LASTMODIFIED], out dateTimeOffset);
+                if (!success)
+                    throw new FormatException($"String \"{response.Headers[HttpUtil.LASTMODIFIED]}\" was not recognized as a valid DateTime");
+                result.Response.LastModified = dateTimeOffset;
+            }
 #else
             result.Response.LastModified = response.LastModified;
 #endif

--- a/src/Hl7.Fhir.Core/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/HttpToEntryExtensions.cs
@@ -50,7 +50,7 @@ namespace Hl7.Fhir.Rest
                 DateTimeOffset dateTimeOffset = new DateTimeOffset();
                 bool success = DateTimeOffset.TryParse(response.Headers[HttpUtil.LASTMODIFIED], out dateTimeOffset);
                 if (!success)
-                    throw new FormatException($"String \"{response.Headers[HttpUtil.LASTMODIFIED]}\" was not recognized as a valid DateTime");
+                    throw new FormatException($"Last-Modified header has value '{response.Headers[HttpUtil.LASTMODIFIED]}', which is not recognized as a valid DateTime");
                 result.Response.LastModified = dateTimeOffset;
             }
 #else


### PR DESCRIPTION
#631 
Fixed: made the exception more clear for NETSTANDARD1_1