### PR TITLE
fix: inconsistent [Obsolete] attribute and some warning clean-up

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -20,10 +20,7 @@ namespace Hl7.Fhir.Rest
 {
     public abstract partial class BaseFhirClient : IDisposable, IFhirClient
     {
-        // [Obsolete]
         public abstract event EventHandler<AfterResponseEventArgs> OnAfterResponse;
-
-        // [Obsolete]
         public abstract event EventHandler<BeforeRequestEventArgs> OnBeforeRequest;
 
         protected IRequester Requester { get; set; }
@@ -382,10 +379,6 @@ namespace Hl7.Fhir.Rest
             // This might be an update of a resource that doesn't yet exist, so accept a status Created too
             return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK });
         }
-        private TResource internalUpdate<TResource>(TResource resource, Bundle tx) where TResource : Resource
-        {
-            return internalUpdateAsync(resource, tx).WaitResult();
-        }
         #endregion
 
         #region Delete
@@ -608,7 +601,7 @@ namespace Hl7.Fhir.Rest
         /// ResourceEntries and DeletedEntries.</returns>
         public Task<Bundle> TypeHistoryAsync<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False) where TResource : Resource, new()
         {
-            string collection = typeof(TResource).GetCollectionName();
+            string collection = ModelInfo.GetFhirTypeNameForType(typeof(TResource));
             return internalHistoryAsync(collection, null, since, pageSize, summary);
         }
         /// <summary>
@@ -718,11 +711,6 @@ namespace Hl7.Fhir.Rest
                 history = new TransactionBuilder(Endpoint).ResourceHistory(resourceType, id, summary, pageSize, since);
 
             return executeAsync<Bundle>(history.ToBundle(), HttpStatusCode.OK);
-        }
-        private Bundle internalHistory(string resourceType = null, string id = null, DateTimeOffset? since = null,
-            int? pageSize = null, SummaryType summary = SummaryType.False)
-        {
-            return internalHistoryAsync(resourceType, id, since, pageSize, summary).WaitResult();
         }
 
         #endregion
@@ -871,12 +859,6 @@ namespace Hl7.Fhir.Rest
             return executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.Accepted });
         }
 
-        private Resource internalOperation(string operationName, string type = null, string id = null,
-            string vid = null, Parameters parameters = null, bool useGet = false)
-        {
-            return internalOperationAsync(operationName, type, id, vid, parameters, useGet).WaitResult();
-        }
-
         #endregion
 
         #region Get
@@ -943,47 +925,12 @@ namespace Hl7.Fhir.Rest
             return result;
         }
 
-
-        // TODO: Depending on type of response, update identity & always update lastupdated?
-
-        private void updateIdentity(Resource resource, ResourceIdentity identity)
-        {
-            if (resource.Meta == null) resource.Meta = new Meta();
-
-            if (resource.Id == null)
-            {
-                resource.Id = identity.Id;
-                resource.VersionId = identity.VersionId;
-            }
-        }
-
-
-        private void setResourceBase(Resource resource, string baseUri)
-        {
-            resource.ResourceBase = new Uri(baseUri);
-
-            if (resource is Bundle)
-            {
-                var bundle = resource as Bundle;
-                foreach (var entry in bundle.Entry.Where(e => e.Resource != null))
-                    entry.Resource.ResourceBase = new Uri(baseUri, UriKind.RelativeOrAbsolute);
-            }
-        }
-
         // Original
-        private TResource execute<TResource>(Bundle tx, HttpStatusCode expect) where TResource : Model.Resource
-        {
-            return executeAsync<TResource>(tx, new[] { expect }).WaitResult();
-        }
         public Task<TResource> executeAsync<TResource>(Model.Bundle tx, HttpStatusCode expect) where TResource : Model.Resource
         {
             return executeAsync<TResource>(tx, new[] { expect });
         }
         // Original
-        private TResource execute<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect) where TResource : Resource
-        {
-            return executeAsync<TResource>(tx, expect).WaitResult();
-        }
 
         private async Task<TResource> executeAsync<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect) where TResource : Resource
         {
@@ -1049,7 +996,8 @@ namespace Hl7.Fhir.Rest
             if (versionChecked) return;
             versionChecked = true;      // So we can now start calling Conformance() without getting into a loop
 
-            CapabilityStatement conf = null;
+            CapabilityStatement conf;
+
             try
             {
                 conf = CapabilityStatement(SummaryType.True); // don't get the full version as its huge just to read the fhir version

--- a/src/Hl7.Fhir.Core/Rest/FhirClientSearch.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClientSearch.cs
@@ -365,7 +365,7 @@ namespace Hl7.Fhir.Rest
         {
             if (id == null) throw Error.ArgumentNull(nameof(id));
 
-            return SearchByIdAsync(typeof(TResource).GetCollectionName(), id, includes, pageSize, revIncludes);
+            return SearchByIdAsync(ModelInfo.GetFhirTypeNameForType(typeof(TResource)), id, includes, pageSize, revIncludes);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace Hl7.Fhir.Rest
         {
             if (id == null) throw Error.ArgumentNull(nameof(id));
 
-            return SearchByIdUsingPostAsync(typeof(TResource).GetCollectionName(), id, includes, pageSize, revIncludes);
+            return SearchByIdUsingPostAsync(ModelInfo.GetFhirTypeNameForType(typeof(TResource)), id, includes, pageSize, revIncludes);
         }
 
         /// <summary>

--- a/src/Hl7.Fhir.Core/Rest/IFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/IFhirClient.cs
@@ -33,14 +33,12 @@ namespace Hl7.Fhir.Rest
         [Obsolete]
         HttpWebResponse LastResponse { get; }
 
-        [Obsolete]
         event EventHandler<AfterResponseEventArgs> OnAfterResponse;
 
-        [Obsolete]
         event EventHandler<BeforeRequestEventArgs> OnBeforeRequest; 
 
-        CapabilityStatement CapabilityStatement(SummaryType? summary = default(SummaryType?));
-        Task<CapabilityStatement> CapabilityStatementAsync(SummaryType? summary = default(SummaryType?));
+        CapabilityStatement CapabilityStatement(SummaryType? summary = default);
+        Task<CapabilityStatement> CapabilityStatementAsync(SummaryType? summary = default);
         Bundle Continue(Bundle current, PageDirection direction = PageDirection.Next);
         Task<Bundle> ContinueAsync(Bundle current, PageDirection direction = PageDirection.Next);
         TResource Create<TResource>(TResource resource) where TResource : Resource;
@@ -60,29 +58,29 @@ namespace Hl7.Fhir.Rest
         Resource Get(Uri url);
         Task<Resource> GetAsync(string url);
         Task<Resource> GetAsync(Uri url);
-        Bundle History(string location, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Bundle History(Uri location, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Task<Bundle> HistoryAsync(string location, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Task<Bundle> HistoryAsync(Uri location, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
+        Bundle History(string location, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Bundle History(Uri location, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Task<Bundle> HistoryAsync(string location, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Task<Bundle> HistoryAsync(Uri location, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
         Resource InstanceOperation(Uri location, string operationName, Parameters parameters = null, bool useGet = false);
         Task<Resource> InstanceOperationAsync(Uri location, string operationName, Parameters parameters = null, bool useGet = false);
         Resource Operation(Uri operation, Parameters parameters = null, bool useGet = false);
         Resource Operation(Uri location, string operationName, Parameters parameters = null, bool useGet = false);
         Task<Resource> OperationAsync(Uri operation, Parameters parameters = null, bool useGet = false);
         Task<Resource> OperationAsync(Uri location, string operationName, Parameters parameters = null, bool useGet = false);
-        TResource Read<TResource>(string location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default(DateTimeOffset?)) where TResource : Resource;
-        TResource Read<TResource>(Uri location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default(DateTimeOffset?)) where TResource : Resource;
-        Task<TResource> ReadAsync<TResource>(string location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default(DateTimeOffset?)) where TResource : Resource;
-        Task<TResource> ReadAsync<TResource>(Uri location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default(DateTimeOffset?)) where TResource : Resource;
+        TResource Read<TResource>(string location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default) where TResource : Resource;
+        TResource Read<TResource>(Uri location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default) where TResource : Resource;
+        Task<TResource> ReadAsync<TResource>(string location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default) where TResource : Resource;
+        Task<TResource> ReadAsync<TResource>(Uri location, string ifNoneMatch = null, DateTimeOffset? ifModifiedSince = default) where TResource : Resource;
         TResource Refresh<TResource>(TResource current) where TResource : Resource;
         Task<TResource> RefreshAsync<TResource>(TResource current) where TResource : Resource;
         Bundle Search(SearchParams q, string resourceType = null);
-        Bundle Search(string resource, string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null);
-        Bundle Search<TResource>(string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null) where TResource : Resource, new();
+        Bundle Search(string resource, string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null);
+        Bundle Search<TResource>(string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null) where TResource : Resource, new();
         Bundle Search<TResource>(SearchParams q) where TResource : Resource;
         Task<Bundle> SearchAsync(SearchParams q, string resourceType = null);
-        Task<Bundle> SearchAsync(string resource, string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null);
-        Task<Bundle> SearchAsync<TResource>(string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null) where TResource : Resource, new();
+        Task<Bundle> SearchAsync(string resource, string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null);
+        Task<Bundle> SearchAsync<TResource>(string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null) where TResource : Resource, new();
         Task<Bundle> SearchAsync<TResource>(SearchParams q) where TResource : Resource;
 
 
@@ -95,10 +93,10 @@ namespace Hl7.Fhir.Rest
         Task<Bundle> SearchUsingPostAsync(string resource, string[] criteria = null, string[] includes = null, int? pageSize = null, SummaryType? summary = null, string[] revIncludes = null);
         Bundle SearchUsingPost(string resource, string[] criteria = null, string[] includes = null, int? pageSize = null, SummaryType? summary = null, string[] revIncludes = null);
 
-        Bundle SearchById(string resource, string id, string[] includes = null, int? pageSize = default(int?), string[] revIncludes = null);
-        Bundle SearchById<TResource>(string id, string[] includes = null, int? pageSize = default(int?), string[] revIncludes = null) where TResource : Resource, new();
-        Task<Bundle> SearchByIdAsync(string resource, string id, string[] includes = null, int? pageSize = default(int?), string[] revIncludes = null);
-        Task<Bundle> SearchByIdAsync<TResource>(string id, string[] includes = null, int? pageSize = default(int?), string[] revIncludes = null) where TResource : Resource, new();
+        Bundle SearchById(string resource, string id, string[] includes = null, int? pageSize = default, string[] revIncludes = null);
+        Bundle SearchById<TResource>(string id, string[] includes = null, int? pageSize = default, string[] revIncludes = null) where TResource : Resource, new();
+        Task<Bundle> SearchByIdAsync(string resource, string id, string[] includes = null, int? pageSize = default, string[] revIncludes = null);
+        Task<Bundle> SearchByIdAsync<TResource>(string id, string[] includes = null, int? pageSize = default, string[] revIncludes = null) where TResource : Resource, new();
 
         Bundle SearchByIdUsingPost(string resource, string id, string[] includes = null, int? pageSize = null, string[] revIncludes = null);
         Bundle SearchByIdUsingPost<TResource>(string id, string[] includes = null, int? pageSize = null, string[] revIncludes = null) where TResource : Resource, new();
@@ -107,10 +105,10 @@ namespace Hl7.Fhir.Rest
 
         Bundle Transaction(Bundle bundle);
         Task<Bundle> TransactionAsync(Bundle bundle);
-        Bundle TypeHistory(string resourceType, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Bundle TypeHistory<TResource>(DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False) where TResource : Resource, new();
-        Task<Bundle> TypeHistoryAsync(string resourceType, DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Task<Bundle> TypeHistoryAsync<TResource>(DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False) where TResource : Resource, new();
+        Bundle TypeHistory(string resourceType, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Bundle TypeHistory<TResource>(DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False) where TResource : Resource, new();
+        Task<Bundle> TypeHistoryAsync(string resourceType, DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Task<Bundle> TypeHistoryAsync<TResource>(DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False) where TResource : Resource, new();
         Resource TypeOperation(string operationName, string typeName, Parameters parameters = null, bool useGet = false);
         Resource TypeOperation<TResource>(string operationName, Parameters parameters = null, bool useGet = false) where TResource : Resource;
         Task<Resource> TypeOperationAsync(string operationName, string typeName, Parameters parameters = null, bool useGet = false);
@@ -119,12 +117,12 @@ namespace Hl7.Fhir.Rest
         TResource Update<TResource>(TResource resource, SearchParams condition, bool versionAware = false) where TResource : Resource;
         Task<TResource> UpdateAsync<TResource>(TResource resource, bool versionAware = false) where TResource : Resource;
         Task<TResource> UpdateAsync<TResource>(TResource resource, SearchParams condition, bool versionAware = false) where TResource : Resource;
-        Bundle WholeSystemHistory(DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
-        Task<Bundle> WholeSystemHistoryAsync(DateTimeOffset? since = default(DateTimeOffset?), int? pageSize = default(int?), SummaryType summary = SummaryType.False);
+        Bundle WholeSystemHistory(DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
+        Task<Bundle> WholeSystemHistoryAsync(DateTimeOffset? since = default, int? pageSize = default, SummaryType summary = SummaryType.False);
         Resource WholeSystemOperation(string operationName, Parameters parameters = null, bool useGet = false);
         Task<Resource> WholeSystemOperationAsync(string operationName, Parameters parameters = null, bool useGet = false);
-        Bundle WholeSystemSearch(string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null);
-        Task<Bundle> WholeSystemSearchAsync(string[] criteria = null, string[] includes = null, int? pageSize = default(int?), SummaryType? summary = default(SummaryType?), string[] revIncludes = null);
+        Bundle WholeSystemSearch(string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null);
+        Task<Bundle> WholeSystemSearchAsync(string[] criteria = null, string[] includes = null, int? pageSize = default, SummaryType? summary = default, string[] revIncludes = null);
 
         Task<Bundle> WholeSystemSearchUsingPostAsync(string[] criteria = null, string[] includes = null, int? pageSize = null, SummaryType? summary = null, string[] revIncludes = null);
         Bundle WholeSystemSearchUsingPost(string[] criteria = null, string[] includes = null, int? pageSize = null, SummaryType? summary = null, string[] revIncludes = null);

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -16,9 +16,6 @@ using Hl7.Fhir.Specification.Source;
 using System.Collections.Generic;
 using System;
 using Hl7.Fhir.Tests;
-using Hl7.Fhir.Specification.Source;
-using System.Collections.Generic;
-using System;
 
 namespace Hl7.Fhir.Serialization.Tests
 {


### PR DESCRIPTION
#971

Some [Obsolete] attributes removed as the plans to remove them have been postponed. Also cleaned up messages and warnings in the fhirclient code.