### PR TITLE
Disable rng-2 fhirpath constraint

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -849,6 +849,31 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         /// <summary>
+        /// This test should show that the rng-2 constraint is totally ignored (it's
+        /// incorrect in DSTU2 and STU3), but others are not.
+        /// </summary>
+        [Fact]
+        public void IgnoreRng2FPConstraint()
+        {           
+            var def = _source.FindStructureDefinitionForCoreType(FHIRDefinedType.Observation);
+
+            var instance = new Observation();
+
+            // this should not trigger rng-2
+            instance.Value = new Range()
+            {
+                Low = new SimpleQuantity() { Value = 5, Code = "kg" },
+                High = new SimpleQuantity() { Value = 4, Code = "kg" },
+            };
+          
+            var report = _validator.Validate(instance, def);
+            Assert.False(report.Success);
+            Assert.Equal(2, report.Errors);  // Obs.status missing, Obs.code missing
+            Assert.Equal(0, report.Warnings);
+        }
+
+
+        /// <summary>
         /// This test proves issue https://github.com/FirelyTeam/fhir-net-api/issues/617
         /// </summary>
         [Fact]

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -36,6 +36,11 @@ namespace Hl7.Fhir.Validation
 
             foreach (var constraintElement in definition.Constraint)
             {
+                // 20190703 Issue 447 - rng-2 is incorrect in DSTU2 and STU3. EK
+                // should be removed from STU3/R4 once we get the new normative version
+                // of FP up, which could do comparisons between quantities.
+                if (constraintElement.Key == "rng-2") continue;
+
                 bool success = false;
                
                 try


### PR DESCRIPTION
#447
#791

As this constraint uses an unsupported FP syntax, we needed to disable it to avoid generating (unsolvable) validation errors.