### PR TITLE
feature: removed dependencies on POCO's in support unit tests

### DIFF
--- a/src/Hl7.Fhir.ElementModel.Tests/SourceNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/SourceNodeTests.cs
@@ -9,14 +9,12 @@
 // To introduce the DSTU2 FHIR specification
 //extern alias dstu2;
 
-using System;
 using Xunit;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
 using System.Linq;
 using Hl7.Fhir.Serialization;
 using System.IO;
-using Hl7.Fhir.Specification;
 
 namespace Hl7.FhirPath.Tests
 {

--- a/src/Hl7.Fhir.ElementModel.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -3,9 +3,6 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Hl7.Fhir.ElementModel.Tests
 {

--- a/src/Hl7.Fhir.Specification.Tests/Validation/IssuesTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/IssuesTests.cs
@@ -2,16 +2,16 @@
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
-namespace Hl7.Fhir.Support.Tests.Model
+namespace Hl7.Fhir.Specification.Tests
 {
     public class IssuesTests
     {
         /// <summary>
         /// See https://github.com/FirelyTeam/fhir-net-api/issues/474
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void Issue474StartdateIs0001_01_01()
         {
             var json = "{ \"resourceType\": \"Patient\", \"active\": true, \"contact\": [{\"organization\": {\"reference\": \"Organization/1\", \"display\": \"Walt Disney Corporation\" }, \"period\": { \"start\": \"0001-01-01\", \"end\": \"2018\" } } ],}";
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.Support.Tests.Model
             var pat = new FhirJsonParser().Parse<Patient>(json);
 
             var report = validator.Validate(pat);
-            Assert.IsTrue(report.Success);
+            Assert.True(report.Success);
         }
     }
 }

--- a/src/Hl7.Fhir.Support.Tests/EnumMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/EnumMappingTest.cs
@@ -58,6 +58,41 @@ namespace Hl7.Fhir.Support.Tests.Utils
         //    Assert.AreEqual("markdown", t.GetDocumentation());
         //}
 
+
+        /// <summary>
+        /// The gender of a person used for administrative purposes.
+        /// (url: http://hl7.org/fhir/ValueSet/administrative-gender)
+        /// </summary>
+        [FhirEnumeration("TestAdministrativeGender")]
+        public enum TestAdministrativeGender
+        {
+            /// <summary>
+            /// Male<br/>
+            /// (system: http://hl7.org/fhir/administrative-gender)
+            /// </summary>
+            [EnumLiteral("male", "http://hl7.org/fhir/administrative-gender"), Utility.Description("Male")]
+            Male,
+            /// <summary>
+            /// Female<br/>
+            /// (system: http://hl7.org/fhir/administrative-gender)
+            /// </summary>
+            [EnumLiteral("female", "http://hl7.org/fhir/administrative-gender"), Utility.Description("Female")]
+            Female,
+            /// <summary>
+            /// Other<br/>
+            /// (system: http://hl7.org/fhir/administrative-gender)
+            /// </summary>
+            [EnumLiteral("other", "http://hl7.org/fhir/administrative-gender"), Utility.Description("Other")]
+            Other,
+            /// <summary>
+            /// Unknown<br/>
+            /// (system: http://hl7.org/fhir/administrative-gender)
+            /// </summary>
+            [EnumLiteral("unknown", "http://hl7.org/fhir/administrative-gender"), Utility.Description("Unknown")]
+            Unknown,
+        }
+
+
         [TestMethod]
         public void EnumParsingPerformance()
         {
@@ -65,7 +100,7 @@ namespace Hl7.Fhir.Support.Tests.Utils
             sw.Start();
 
             for(var i=0; i < 10000; i++)
-                EnumUtility.ParseLiteral<AdministrativeGender>("male");
+                EnumUtility.ParseLiteral<TestAdministrativeGender>("male");
 
             sw.Stop();
 
@@ -76,11 +111,11 @@ namespace Hl7.Fhir.Support.Tests.Utils
         [TestMethod]
         public void TestEnumMapping()
         {
-            Assert.AreEqual(AdministrativeGender.Male, EnumUtility.ParseLiteral<AdministrativeGender>("male"));
-            Assert.IsNull(EnumUtility.ParseLiteral<AdministrativeGender>("maleX"));
+            Assert.AreEqual(TestAdministrativeGender.Male, EnumUtility.ParseLiteral<TestAdministrativeGender>("male"));
+            Assert.IsNull(EnumUtility.ParseLiteral<TestAdministrativeGender>("maleX"));
             Assert.AreEqual(X.a, EnumUtility.ParseLiteral<X>("a"));
 
-            Assert.AreEqual("Male",AdministrativeGender.Male.GetDocumentation());
+            Assert.AreEqual("Male",TestAdministrativeGender.Male.GetDocumentation());
             Assert.AreEqual("a", X.a.GetDocumentation()); // default documentation = name of item
         }
 

--- a/src/Hl7.Fhir.Support.Tests/Hl7.Fhir.Support.Tests.csproj
+++ b/src/Hl7.Fhir.Support.Tests/Hl7.Fhir.Support.Tests.csproj
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Hl7.Fhir.Core\Hl7.Fhir.Core.csproj" />
-    <ProjectReference Include="..\Hl7.Fhir.Specification\Hl7.Fhir.Specification.csproj" />
+    <ProjectReference Include="..\Hl7.Fhir.Serialization\Hl7.Fhir.Serialization.csproj" />
     <ProjectReference Include="..\Hl7.Fhir.Support\Hl7.Fhir.Support.csproj" />
   </ItemGroup>
 

--- a/src/Hl7.Fhir.Support.Tests/Utils/JsonAssert.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utils/JsonAssert.cs
@@ -7,7 +7,6 @@
  */
 
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
 using System;


### PR DESCRIPTION
The unit tests for the support library had references on the POCO libraries, but it was easy to replace them so this dependency is no longer necessary.