### PR TITLE
Support variables either internally or externally

### DIFF
--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -22,6 +22,15 @@ namespace Hl7.FhirPath
 
         public Action<string, IEnumerable<ITypedElement>> Tracer { get; set; }
 
+        public Func<string, IEnumerable<ITypedElement>> ExternalVariableResolver { private get; set; }
+
+        public IEnumerable<ITypedElement> ResolveVariable(string name)
+        {
+            if (ExternalVariableResolver != null)
+                return ExternalVariableResolver(name);
+            return ElementNode.EmptyList;
+        }
+
         #region Obsolete members
         [Obsolete("Please use CreateDefault() instead of this member, which may cause raise conditions.")]
         public static readonly EvaluationContext Default = new EvaluationContext();

--- a/src/Hl7.FhirPath/FhirPath/Expressions/Invokee.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/Invokee.cs
@@ -187,7 +187,7 @@ namespace Hl7.FhirPath.Expressions
                 }
                 catch (Exception e)
                 {
-                    throw new InvalidOperationException("Invocation of '{0}' failed: {1}".FormatWith(functionName, e.Message));
+                    throw new InvalidOperationException("Invocation of '{0}' failed: {1}".FormatWith(functionName, e.Message), e);
                 }
             };
         }

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -156,6 +156,7 @@ namespace Hl7.FhirPath.Expressions
             t.AddVar("loinc", "http://loinc.org");
             t.AddVar("ucum", "http://unitsofmeasure.org");
 
+            // What are these 2 things? Don't look like core routines
             t.Add("builtin.coreexturl", (object f, string id) => getCoreExtensionUrl(id));
             t.Add("builtin.corevsurl", (object f, string id) => getCoreValueSetUrl(id));
 


### PR DESCRIPTION
#900 Support adding your own variables
There are still a few gotcha's with this, e.g. you shouldn't be doing this with the default symbol table, unless you're wanting to, such as with %ucum
Both modes of use work with CompiledExpression, and only resolve the value at execution time, not plan creation time.
The internal variables are provided through a dictionary in the symbol table, that works through the parent chains, or through external variables via a callback func on the lowest symbol table to resolve the names, and a callback func on the EvaluationContext to retrieve the actual value.