### PR TITLE
fix: #1067 Incorrect root element base

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -39,6 +39,7 @@ namespace Hl7.Fhir.Specification.Tests
 #endif
     {
         SnapshotGenerator _generator;
+        ZipSource _zipSource;
         IResourceResolver _testResolver;
         TimingSource _source;
 
@@ -62,11 +63,8 @@ namespace Hl7.Fhir.Specification.Tests
             // [WMR 20170810] Order is important!
             // Specify source first to override core defs from
             // TestData\snapshot-test\profiles-resources.xml and profiles-types.xml
-            _testResolver = new CachedResolver(
-                new MultiResolver(
-                    // _source,
-                    new ZipSource("specification.zip"),
-                    _source));
+            _zipSource = new ZipSource("specification.zip");
+            _testResolver = new CachedResolver(new MultiResolver(_zipSource, _source));
         }
 
         [TestMethod]
@@ -1843,6 +1841,93 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
+        // [WMR 20190805] Updated, verify base annotation on extension definition root element
+        // Should point to core "Extension", not "Element"
+        [TestMethod]
+        public void TestBaseAnnotations_ExtensionDefinition()
+        {
+            const string url = @"http://example.org/fhir/StructureDefinition/MyTestExtension";
+            var sd = new StructureDefinition()
+            {
+                Type = FHIRAllTypes.Extension.GetLiteral(),
+                BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Extension),
+                Name = "MyTestExtension",
+                Url = url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Kind = StructureDefinition.StructureDefinitionKind.ComplexType,
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>()
+                    {
+                        new ElementDefinition("Extension")
+                        {
+                            Short = "TEST"
+                        },
+                        new ElementDefinition("Extension.url")
+                        {
+                            Fixed = new FhirString(url)
+                        }
+                    }
+                }
+            };
+
+            var source = new CachedResolver(new MultiResolver(_zipSource, new InMemoryProfileResolver(sd)));
+
+            var settings = new SnapshotGeneratorSettings(_settings);
+            settings.GenerateAnnotationsOnConstraints = true;
+            _generator = new SnapshotGenerator(source, settings);
+
+            try
+            {
+                _generator.PrepareBaseProfile += profileHandler;
+                _generator.PrepareElement += elementHandler;
+                _generator.Constraint += constraintHandler;
+
+
+                // Replace root element and re-expand
+                var coreExtension = source.FindStructureDefinitionForCoreType(FHIRAllTypes.Extension);
+                
+                // [WMR 20190806] SnapGen should never expose/leak internal annotations
+                Debug.Assert(!coreExtension.Differential.Element[0].HasSnapshotElementAnnotation());
+
+                Assert.IsNotNull(coreExtension);
+                coreExtension.Snapshot = null;
+                _generator.Update(coreExtension);
+
+                Assert.IsTrue(coreExtension.HasSnapshot);
+                var coreDiffRoot = coreExtension.Differential.Element[0];
+                var coreSnapRoot = coreExtension.Snapshot.Element[0];
+
+                // [WMR 20190806] SnapGen should never expose/leak internal annotations
+                Debug.Assert(!coreDiffRoot.HasSnapshotElementAnnotation());
+
+                var userDiffRoot = (ElementDefinition)coreDiffRoot.DeepCopy();
+
+                sd.Differential.Element[0] = userDiffRoot;
+
+                var expanded = _generator.Generate(sd);
+                dumpOutcome(_generator.Outcome);
+                assertBaseDefs(expanded, settings);
+
+                var userSnapRoot = expanded[0];
+                Assert.AreNotSame(coreSnapRoot, userSnapRoot);
+                Assert.IsTrue(userSnapRoot.TryGetAnnotation<BaseDefAnnotation>(out var anno));
+                Assert.AreEqual("Extension", anno.BaseStructureDefinition.Name);
+                Assert.AreEqual("Extension", anno.BaseElementDefinition.Path);
+
+                // [WMR 20190806] SnapGen should never expose/leak internal annotations
+                Debug.Assert(!userDiffRoot.HasSnapshotElementAnnotation());
+
+            }
+            finally
+            {
+                // Detach event handlers
+                _generator.Constraint -= constraintHandler;
+                _generator.PrepareElement -= elementHandler;
+                _generator.PrepareBaseProfile -= profileHandler;
+            }
+        }
+
         // [WMR 20170714] NEW
         // Annotated Base Element for backbone elements is not included in base structuredefinition ?
 
@@ -1983,15 +2068,20 @@ namespace Hl7.Fhir.Specification.Tests
         {
             Assert.IsNotNull(sd);
             Assert.IsNotNull(sd.Snapshot);
-            var elems = sd.Snapshot.Element;
+            Debug.WriteLine("\r\nStructureDefinition '{0}' url = '{1}'", sd.Name, sd.Url);
+            assertBaseDefs(sd.Snapshot.Element, settings);
+        }
+
+        static void assertBaseDefs(List<ElementDefinition> elems, SnapshotGeneratorSettings settings)
+        {
             Assert.IsNotNull(elems);
             Assert.IsTrue(elems.Count > 0);
 
-            var isConstraint = sd.Derivation == StructureDefinition.TypeDerivationRule.Constraint;
+            //var isConstraint = sd.Derivation == StructureDefinition.TypeDerivationRule.Constraint;
 
-            Debug.Print("\r\nStructureDefinition '{0}' url = '{1}'", sd.Name, sd.Url);
-            Debug.Print("# | Constraints? | Changed? | Element.Path | Element.Base.Path | BaseElement.Path | #Base | Redundant?");
-            Debug.Print(new string('=', 100));
+            Debug.WriteLine("# | Constraints? | Changed? | Element.Path | Element.Base.Path | BaseElement.Path | #Base | Redundant?");
+            Debug.WriteLine(new string('=', 100));
+
             foreach (var elem in elems)
             {
                 // Each element should have a valid Base component, unless the profile is a core type/resource definition (no base)

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/ProfileNavigationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/ProfileNavigationExtensions.cs
@@ -265,8 +265,15 @@ namespace Hl7.Fhir.Specification.Navigation
         /// <summary>Returns the root element from the specified element list, if available, or <c>null</c>.</summary>
         public static ElementDefinition GetRootElement(this IElementList elements)
         {
-            return elements?.Element?.FirstOrDefault(e => e.IsRootElement());
+            return elements?.Element.GetRootElement();
         }
+
+        /// <summary>Returns the root element from the specified element list, if available, or <c>null</c>.</summary>
+        internal static ElementDefinition GetRootElement(this List<ElementDefinition> elements)
+        {
+            return elements?.FirstOrDefault(e => e.IsRootElement());
+        }
+
     }
 }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/DifferentialTreeConstructor.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/DifferentialTreeConstructor.cs
@@ -42,7 +42,13 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <remarks>This method returns a new list of element definitions. The input elements list is not modified.</remarks>
         public static List<ElementDefinition> MakeTree(List<ElementDefinition> elements)
         {
-            var diff = new List<ElementDefinition>(elements.DeepCopy());   // We're going to modify the differential
+            // We're going to modify the differential
+            //var diff = new List<ElementDefinition>(elements.DeepCopy());   
+
+            // [WMR 20190806] No need to clone the individual elements
+            // Create a new result list; don't modify the original list
+            // Especially important to prevent cloning (internal) annotations...!
+            var diff = new List<ElementDefinition>(elements);
 
             if (diff.Count == 0 ) return diff;        // nothing to do
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -290,6 +290,11 @@ namespace Hl7.Fhir.Specification.Snapshot
                     return null;
                 }
 
+                // [WMR 20190806] Expanding the base profile *may* recurse on current structure
+                // e.g. Extension : BaseDefinition => Element : Element.extension => Extension
+                // Then snapshot root is already generated and annotated to differential.Element[0]
+                //Debug.WriteLineIf(differential.Element[0].HasSnapshotElementAnnotation(), $"[{nameof(SnapshotGenerator)}.{nameof(generate)} (1)] diff[0] is annotated with cached snapshot root...");
+
                 // [WMR 20160817] Notify client about the resolved, expanded base profile
                 OnPrepareBaseProfile(structure, baseStructure);
 
@@ -377,13 +382,32 @@ namespace Hl7.Fhir.Specification.Snapshot
             var diff = new ElementDefinitionNavigator(fullDifferential);
 
 #if FIX_SLICENAMES_ON_ROOT_ELEMENTS
-            var diffRoot = differential.GetRootElement();
+            var diffRoot = fullDifferential.GetRootElement();
             fixInvalidSliceNameOnRootElement(diffRoot, structure);
 #endif
+
+            // [WMR 20190806] Expanding the base profile *may* recurse on current structure
+            // e.g. Extension : BaseDefinition => Element : Element.extension => Extension
+            // Then snapshot root is already generated and annotated to differential.Element[0]
+            //Debug.WriteLineIf(diffRoot.HasSnapshotElementAnnotation(), $"[{nameof(SnapshotGenerator)}.{nameof(generate)} (before merge)] diff root is annotated with cached snapshot root...");
 
             merge(nav, diff);
 
             result = nav.ToListOfElements();
+
+            //Debug.WriteLineIf(diffRoot.HasSnapshotElementAnnotation(), $"[{nameof(SnapshotGenerator)}.{nameof(generate)} (after merge)] diff root is annotated with cached snapshot root...");
+
+            // Ready! Snapshot has been generated
+
+#if CACHE_ROOT_ELEMDEF
+            // [WMR 20190806] Never expose/leak internal temporary annotations!
+            // Only for handling internal profile recursion, e.g. Extension => Extension.extension
+            // Remove the temporary annotation on differential root element
+            // Cached root element annotation only applies to *this* instance
+            // User could generate new structure by cloning Differential (esp. root element)
+            // Cloning existing annotations would corrupt the new snapshot...
+            diffRoot.RemoveSnapshotElementAnnotations();
+#endif
 
             return result;
         }
@@ -651,6 +675,11 @@ namespace Hl7.Fhir.Specification.Snapshot
             {
                 var clonedElem = (ElementDefinition)diff.Current.DeepCopy();
 
+#if CACHE_ROOT_ELEMDEF
+                // [WMR 20190806] Never clone temporary internal annotation!
+                clonedElem.RemoveSnapshotElementAnnotations(); // Paranoia...
+#endif
+
                 // [WMR 20160915] NEW: Notify subscribers
                 OnPrepareElement(clonedElem, null, null);
 
@@ -686,26 +715,30 @@ namespace Hl7.Fhir.Specification.Snapshot
             var diffElem = diff.Current;
             var isRoot = diffElem.IsRootElement();
 
-            ElementDefinition cachedRootElemDef = null;
-            if (isRoot && (cachedRootElemDef = diffElem.GetSnapshotElementAnnotation()) != null)
+            if (isRoot && diffElem.GetSnapshotElementAnnotation() is ElementDefinition cachedRootElemDef)
             {
 
 #if CACHE_ROOT_ELEMDEF_ASSERT
                 // DEBUG / VERIFY: merge results should be equal to cached ElemDef instance
-                isValid = mergeTypeProfiles(snap, diff);
-                mergeElementDefinition(snap.Current, elem);
+                var isValid = mergeTypeProfiles(snap, diff);
+                mergeElementDefinition(snap.Current, diff.Current, true);
                 var currentRootClone = (ElementDefinition)snap.Current.DeepCopy();
                 var cachedRootClone = (ElementDefinition)cachedRootElemDef.DeepCopy();
                 // Ignore Id, Path, Base and ChangedByDiff extension - they are expected to differ
                 currentRootClone.ElementId = cachedRootClone.ElementId;
                 currentRootClone.Path = cachedRootClone.Path;
                 currentRootClone.Base = cachedRootClone.Base;
-                currentRootClone.RemoveAllChangedByDiff();
-                cachedRootClone.RemoveAllChangedByDiff();
+                currentRootClone.RemoveAllConstrainedByDiffAnnotations();
+                cachedRootClone.RemoveAllConstrainedByDiffAnnotations();
                 Debug.Assert(cachedRootClone.IsExactly(currentRootClone));
 #endif
 
-                // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(mergeElement)}] Re-use cached root element definition: '{cachedRootElemDef.Path}'  #{cachedRootElemDef.GetHashCode()}");
+                // Found temporary annotation to generated snapshot root element on diff root element
+                // (assigned previously by recursive snapshot expansions)
+                // Insert snapshot root element into the specified snapshot element list
+                // and remove the temporary annotation
+
+                //Debug.WriteLine($"[{nameof(SnapshotGenerator)}.{nameof(mergeElement)} ANNOTATIONS] Replace original element at position {snap.OrdinalPosition.Value} #{snap.Elements[snap.OrdinalPosition.Value]?.GetHashCode()} with cached root element definition: '{cachedRootElemDef.Path}'  #{cachedRootElemDef.GetHashCode()}");
                 snap.Elements[snap.OrdinalPosition.Value] = cachedRootElemDef;
                 diffElem.RemoveSnapshotElementAnnotations();
             }
@@ -1832,13 +1865,20 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Structure has no base, i.e. core type definition => differential introduces & defines the root element
                 // No need to rebase, nothing to merge
-                var clonedDiffRoot = (ElementDefinition)diffRoot.DeepCopy();
+                var snapRoot = (ElementDefinition)diffRoot.DeepCopy();
+
 #if CACHE_ROOT_ELEMDEF
-                clonedDiffRoot.EnsureBaseComponent(null, true);
-                sd.SetSnapshotRootElementAnnotation(clonedDiffRoot);
+                Debug.Assert(!snapRoot.HasSnapshotElementAnnotation());
+
+                snapRoot.EnsureBaseComponent(null, true);
+                sd.SetSnapshotRootElementAnnotation(snapRoot);
+
+                //Debug.WriteLine($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)} ANNOTATIONS] Cache root element definition for structure '{sd.Name}': '{clonedDiffRoot.Path}'  #{clonedDiffRoot.GetHashCode()}");
+                // [WMR 20190805] IMPORTANT! Always explicitly clear the annotation before returning result to caller
+                // Otherwise, cloning & expanding the result will pick up incorrect root element from original... WRONG!
 #endif
                 // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)}] {nameof(profileUri)} = '{profileUri}' - use root element definition from differential: #{clonedDiffRoot.GetHashCode()}");
-                return clonedDiffRoot;
+                return snapRoot;
             }
 
             // Recursively resolve root element definition from base profile
@@ -1863,6 +1903,12 @@ namespace Hl7.Fhir.Specification.Snapshot
             // Clone and rebase
             var rebasedRoot = (ElementDefinition)baseRoot.DeepCopy();
 
+#if CACHE_ROOT_ELEMDEF
+            // [WMR 20190806] Paranoia: never clone temporary internal annotation
+            Debug.Assert(!rebasedRoot.HasSnapshotElementAnnotation());
+            //rebasedRoot.RemoveSnapshotElementAnnotations(); // Paranoia...
+#endif
+
             if (diffRoot != null)
             {
                 rebasedRoot.Path = diffRoot.Path;
@@ -1880,6 +1926,8 @@ namespace Hl7.Fhir.Specification.Snapshot
             // When generating the full snapshot, re-use the previously generated root element definition
             rebasedRoot.EnsureBaseComponent(baseRoot, true);
             sd.SetSnapshotRootElementAnnotation(rebasedRoot);
+
+            //Debug.WriteLine($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)}] Annotation snapshot root element for structure '{sd.Name}': '{rebasedRoot.Path}'  #{rebasedRoot.GetHashCode()}");
 #endif
 
             // Notify observers


### PR DESCRIPTION
Fix for #1067 - Never expose/leak temporary internal annotations
Identical to fix for R4