### PR TITLE
fix: handle extension() discriminators with local constraints [stu3]

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
@@ -106,6 +106,18 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
+        public void WalkToInlineExtensionConstraints()
+        {
+            var walker = new StructureDefinitionWalker(_source.FindStructureDefinition("http://example.org/fhir/StructureDefinition/observation-profile-for-discriminator-test"), _source);
+
+            var elem = walker.Walk("identifier.extension('http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test').value").Single();
+            var fixedString = elem.Current.Current.Fixed;
+
+            Assert.IsTrue(fixedString is FhirString);
+            Assert.AreEqual("hi!", ((FhirString)elem.Current.Current.Fixed).Value);
+        }
+
+        [TestMethod]
         public void ParseInvalidDiscriminatorExpressions()
         {
             var patientDef = _source.FindStructureDefinitionForCoreType(FHIRAllTypes.Patient);

--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
@@ -40,20 +40,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <None Remove="TestData\CustomBasic-StructureDefinition-R3.json" />
-    <None Remove="TestData\profiles-types.json" />
-    <None Remove="TestData\ResourcesInSubfolder.zip" />
-    <None Remove="TestData\validation\obs-with-sliced-value.xml" />
-  </ItemGroup>
 
-  <!--
   <ItemGroup>
-    <Compile Include="..\Hl7.Fhir.Core.Tests\TestDataHelper.cs" Link="TestDataHelper.cs" />
-    <Compile Include="Source\Summary\ArtifactSummaryProperties.cs" />
+    <None Remove="TestData\validation\observation-profile-for-discriminator-test.xml" />
   </ItemGroup>
-
-  -->
+  
   <ItemGroup>
     <Content Include="..\Hl7.Fhir.Specification\data\profiles-resources.xml" Link="TestData\snapshot-test\profiles-resources.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/validation/observation-profile-for-discriminator-test.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/validation/observation-profile-for-discriminator-test.xml
@@ -1,0 +1,68 @@
+﻿<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="http://example.org/fhir/StructureDefinition/observation-profile-for-discriminator-test"/>
+  <name value="MyObservation"/>
+  <status value="draft"/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Observation"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Observation.identifier">
+      <path value="Observation.identifier"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="extension('http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test').value"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Observation.identifier.extension">
+      <path value="Observation.identifier.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Observation.identifier.extension:myExtension">
+      <path value="Observation.identifier.extension"/>
+      <sliceName value="myExtension"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test"/>
+      </type>
+    </element>
+    <element id="Observation.identifier:someCustomIdentifier">
+      <path value="Observation.identifier"/>
+      <sliceName value="someCustomIdentifier"/>
+    </element>
+    <element id="Observation.identifier:someCustomIdentifier.extension">
+      <path value="Observation.identifier.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Observation.identifier:someCustomIdentifier.extension:myExtension">
+      <path value="Observation.identifier.extension"/>
+      <sliceName value="myExtension"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test"/>
+      </type>
+    </element>
+    <element id="Observation.identifier:someCustomIdentifier.extension:myExtension.valueString:valueString">
+      <path value="Observation.identifier.extension.valueString"/>
+      <sliceName value="valueString"/>
+      <fixedString value="hi!"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/validation/string-extension-for-discriminator-test.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/validation/string-extension-for-discriminator-test.xml
@@ -1,0 +1,47 @@
+﻿<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test"/>
+  <name value="MyExtension"/>
+  <status value="draft"/>
+  <fhirVersion value="3.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <contextType value="resource"/>
+  <context value="Observation.identifier"/>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Optional Extensions Element"/>
+      <definition value="Optional Extension Element - found in all resources."/>
+      <base>
+        <path value="Element"/>
+        <min value="0"/>
+        <max value="*"/>
+      </base>
+      <constraint>
+        <key value="ext-1"/>
+        <severity value="error"/>
+        <human value="Must have either extensions or value[x], not both"/>
+        <expression value="extension.exists() != value.exists()"/>
+        <xpath value="exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])"/>
+      </constraint>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://example.org/fhir/StructureDefinition/string-extension-for-discriminator-test"/>
+    </element>
+    <element id="Extension.value[x]:valueString">
+      <path value="Extension.valueString"/>
+      <sliceName value="valueString"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Will now handle extension() discriminators where the profile calling an extension has local (inline) constraints on the extension, and you want to discriminate on those, rather than the ones in the referenced extension.