### PR TITLE
fix: Call WebRequest.Abort on timeout

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/WebRequestExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/WebRequestExtensions.cs
@@ -120,7 +120,10 @@ namespace Hl7.Fhir.Rest
                     try
                     {
                         if (!t.Wait(timeout))
+                        {
+                            request.Abort();
                             throw new TimeoutException();
+                        }
                     }
                     catch (AggregateException we)
                     {


### PR DESCRIPTION
* Call WebRequest.Abort on timeout
* Fixes issue #1093