### PR TITLE
465 Detect circular references

### DIFF
--- a/src/Hl7.Fhir.Core/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Core/ElementModel/ScopedNodeExtensions.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.ElementModel
 {
     public static class ScopedNodeExtensions
     {
-        public static string MakeAbsolute(this ScopedNode node, string reference) =>
+        public static string MakeAbsolute(this BaseScopedNode node, string reference) =>
                      node.MakeAbsolute(new ResourceIdentity(reference)).ToString();
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.ElementModel
         /// <param name="identity"></param>
         /// <returns></returns>
         /// <remarks>See https://www.hl7.org/fhir/bundle.html#references for more information</remarks>
-        public static ResourceIdentity MakeAbsolute(this ScopedNode node, ResourceIdentity identity)
+        public static ResourceIdentity MakeAbsolute(this BaseScopedNode node, ResourceIdentity identity)
         {
             if (identity.IsRelativeRestUrl)
             {
@@ -53,7 +53,7 @@ namespace Hl7.Fhir.ElementModel
         {
             // Then, resolve the url within the instance data first - this is only
             // possibly if we have a ScopedNavigator at hand
-            if (element is ScopedNode scopedNode)
+            if (element is BaseScopedNode scopedNode)
             {
                 var identity = scopedNode.MakeAbsolute(new ResourceIdentity(reference));
 
@@ -70,7 +70,7 @@ namespace Hl7.Fhir.ElementModel
             else
                 return null;
 
-            ScopedNode locateResource(ResourceIdentity identity)
+            BaseScopedNode locateResource(ResourceIdentity identity)
             {
                 var url = identity.ToString();
 

--- a/src/Hl7.Fhir.Specification/ElementModel/ScopedNodeWrapper.cs
+++ b/src/Hl7.Fhir.Specification/ElementModel/ScopedNodeWrapper.cs
@@ -1,0 +1,78 @@
+﻿using Hl7.Fhir.Specification;
+using Hl7.Fhir.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.ElementModel
+{
+    internal class ScopedNodeWrapper : BaseScopedNode
+    {
+        private BaseScopedNode _current;
+
+        public ScopedNodeWrapper(BaseScopedNode scopedNode)
+        {
+            ValidatedProfiles = new List<ValidatedProfile>();
+            _current = scopedNode;
+            ParentResource = scopedNode.ParentResource;
+        }
+
+        private ScopedNodeWrapper(BaseScopedNode parent, BaseScopedNode parentResource, BaseScopedNode scopedNode)
+        {
+            ValidatedProfiles = new List<ValidatedProfile>();
+            _current = scopedNode;
+            ParentResource = parent.AtResource ? parent : parentResource;
+        }
+
+        public override ITypedElement Current => _current.Current;
+
+        public override string Name => _current.Name;
+
+        public override string InstanceType => _current.InstanceType;
+
+        public override object Value => _current.Value;
+
+        public override string Location => _current.Location;
+
+        public override IElementDefinitionSummary Definition => _current.Definition;
+
+        public override ExceptionNotificationHandler ExceptionHandler { get { return _current.ExceptionHandler; } set { _current.ExceptionHandler = value; } }
+
+        public override string LocalLocation => _current.LocalLocation;
+
+        public override bool AtResource => _current.AtResource;
+
+        public override IEnumerable<ITypedElement> Children(string name = null) => _current.Children(name).Select(t => new ScopedNodeWrapper(this, this.ParentResource, t as ScopedNode));
+
+        public override IEnumerable<object> Annotations(Type type)
+        {
+            if (type == typeof(ScopedNodeWrapper) || type == typeof(BaseScopedNode))
+                return new[] { this };
+            else
+                return Current.Annotations(type);
+        }
+
+        public List<ValidatedProfile> ValidatedProfiles { get; set; }
+    }
+
+    public class ValidatedProfile
+    {
+        public string Profile { get; }
+        public Status Success { get; internal set; }
+
+        public ValidatedProfile(string profile, Status status)
+        {
+            Profile = profile;
+            Success = status;
+        }
+
+        public enum Status
+        {
+            Pending,
+            Success,
+            Fail
+        }
+    }
+}

--- a/src/Hl7.Fhir.Specification/Support/Issue.cs
+++ b/src/Hl7.Fhir.Specification/Support/Issue.cs
@@ -89,6 +89,7 @@ namespace Hl7.Fhir.Support
         public static readonly Issue CONTENT_ELEMENT_SLICING_OUT_OF_ORDER = Create(1027, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_INCORRECT_OCCURRENCE = Create(1028, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue CONTENT_ELEMENT_NAME_DOESNT_MATCH_DEFINITION = Create(1029, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_CIRCULAR_REFERENCE = Create(1030, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
 
         public static readonly Issue XSD_VALIDATION_ERROR = Create(1100, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
         public static readonly Issue XSD_VALIDATION_WARNING = Create(1101, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Hl7.Fhir.Validation
@@ -19,7 +20,7 @@ namespace Hl7.Fhir.Validation
     internal static class ChildConstraintValidationExtensions
     {
         internal static OperationOutcome ValidateChildConstraints(this Validator validator, ElementDefinitionNavigator definition, 
-            ScopedNode instance, bool allowAdditionalChildren)
+            BaseScopedNode instance, bool allowAdditionalChildren, List<Tuple<string, string>> validatedResources = null)
         {
             var outcome = new OperationOutcome();
             if (!definition.HasChildren) return outcome;
@@ -41,13 +42,13 @@ namespace Hl7.Fhir.Validation
             // Recursively validate my children
             foreach (var match in matchResult.Matches)
             {
-                outcome.Add(validator.ValidateMatch(match, instance));
+                outcome.Add(validator.ValidateMatch(match, instance, validatedResources));
             }
 
             return outcome;
         }
 
-        private static OperationOutcome ValidateMatch(this Validator validator, Match match, ScopedNode parent)
+        private static OperationOutcome ValidateMatch(this Validator validator, Match match, BaseScopedNode parent, List<Tuple<string, string>> validatedResources = null)
         {
             var outcome = new OperationOutcome();
 
@@ -85,7 +86,7 @@ namespace Hl7.Fhir.Validation
                 // Since the ChildNameMatcher currently does the matching, this will never go wrong
             }
 
-            outcome.Add(bucket.Validate(validator, parent));
+            outcome.Add(bucket.Validate(validator, parent, validatedResources));
 
             return outcome;
         }

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Validation
 
     internal static class FpConstraintValidationExtensions
     {
-        public static OperationOutcome ValidateFp(this Validator v, string structureDefinitionUrl, ElementDefinition definition, ScopedNode instance)
+        public static OperationOutcome ValidateFp(this Validator v, string structureDefinitionUrl, ElementDefinition definition, BaseScopedNode instance)
         {
             var outcome = new OperationOutcome();
 

--- a/src/Hl7.Fhir.Specification/Validation/InstanceToProfileMatcher.cs
+++ b/src/Hl7.Fhir.Specification/Validation/InstanceToProfileMatcher.cs
@@ -21,7 +21,7 @@ namespace Hl7.Fhir.Validation
         public static MatchResult Match(ElementDefinitionNavigator definitionParent, ITypedElement instanceParent)
         {
             var definitionElements = harvestDefinitionNames(definitionParent);
-            var elementsToMatch = instanceParent.Children().Cast<ScopedNode>().ToList();
+            var elementsToMatch = instanceParent.Children().Cast<BaseScopedNode>().ToList();
 
             List<Match> matches = new List<Match>();
 
@@ -106,7 +106,7 @@ namespace Hl7.Fhir.Validation
     internal class MatchResult
     {
         public List<Match> Matches;
-        public List<ScopedNode> UnmatchedInstanceElements;
+        public List<BaseScopedNode> UnmatchedInstanceElements;
     }
 
     [System.Diagnostics.DebuggerDisplay(@"\{{Definition.DebuggerDisplay,nq}}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
@@ -1,6 +1,7 @@
 ﻿using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
+using System;
 using System.Collections.Generic;
 
 namespace Hl7.Fhir.Validation
@@ -19,7 +20,7 @@ namespace Hl7.Fhir.Validation
 
         public abstract bool Add(ITypedElement instance);
   
-        public virtual OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
+        public virtual OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string, string>> validatedResources = null)
         {
             var outcome = new OperationOutcome();
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
@@ -10,6 +10,8 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.ElementModel;
+using System.Collections.Generic;
+using System;
 
 namespace Hl7.Fhir.Validation
 {
@@ -46,7 +48,7 @@ namespace Hl7.Fhir.Validation
                 return false;
         }
 
-        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
+        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string, string>> validatedResources = null)
         {
             return base.Validate(validator, errorLocation);
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/DiscriminatorBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/DiscriminatorBucket.cs
@@ -12,6 +12,8 @@ using Hl7.Fhir.Support;
 using System.Linq;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
+using System.Collections.Generic;
+using System;
 
 namespace Hl7.Fhir.Validation
 {
@@ -54,7 +56,7 @@ namespace Hl7.Fhir.Validation
                 return false;
         }
 
-        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
+        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string, string>> validatedResources = null)
         {
             OperationOutcome outcome = new OperationOutcome();
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
@@ -10,6 +10,8 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.ElementModel;
+using System;
+using System.Collections.Generic;
 
 namespace Hl7.Fhir.Validation
 {
@@ -32,13 +34,13 @@ namespace Hl7.Fhir.Validation
         }
 
 
-        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
+        public override OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string,string>> validatedResources = null)
         {
             var outcome = base.Validate(validator, errorLocation);
 
             foreach(var member in Members)
             {
-                outcome.Include(Validator.Validate(member, Root));
+                outcome.Include(Validator.Validate(member, Root, validatedResources: validatedResources));
             }
 
             return outcome;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/IBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/IBucket.cs
@@ -9,6 +9,7 @@
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.ElementModel;
+using System;
 
 namespace Hl7.Fhir.Validation
 {
@@ -35,6 +36,6 @@ namespace Hl7.Fhir.Validation
 
         IList<ITypedElement> Members { get; }
 
-        OperationOutcome Validate(Validator validator, ITypedElement errorLocation);
+        OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string, string>> validatedResources = null);
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/SliceGroupBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/SliceGroupBucket.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
+using System;
 
 namespace Hl7.Fhir.Validation
 {
@@ -58,9 +59,9 @@ namespace Hl7.Fhir.Validation
             return Entry.Add(candidate);
         }
 
-        public OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
+        public OperationOutcome Validate(Validator validator, ITypedElement errorLocation, List<Tuple<string, string>> validatedResources = null)
         {
-            var outcome = Entry.Validate(validator, errorLocation);   // Validate against entry slice, e.g. total cardinality
+            var outcome = Entry.Validate(validator, errorLocation, validatedResources);   // Validate against entry slice, e.g. total cardinality
 
             var overallLastMatchingSlice = -1;
             var openTailInUse = false;
@@ -125,7 +126,7 @@ namespace Hl7.Fhir.Validation
             // Finally, add any validation items on the elements that made it into the child slices
             foreach (var slice in ChildSlices)
             {
-                var sliceOutcome = slice.Validate(validator, errorLocation);
+                var sliceOutcome = slice.Validate(validator, errorLocation, validatedResources);
                 foreach (var issue in sliceOutcome.Issue)
                 {
                     // Only add the issue from the slice outcome if the entry validation did not already catch

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Schema;
 using Hl7.Fhir.Specification.Snapshot;
@@ -142,14 +143,14 @@ namespace Hl7.Fhir.Validation
         #endregion
 
         // This is the one and only main entry point for all external validation calls (i.e. invoked by the user of the API)
-        internal OperationOutcome Validate(ITypedElement instance, string declaredTypeProfile, IEnumerable<string> statedCanonicals, IEnumerable<StructureDefinition> statedProfiles)
+        internal OperationOutcome Validate(ITypedElement instance, string declaredTypeProfile, IEnumerable<string> statedCanonicals, IEnumerable<StructureDefinition> statedProfiles, List<Tuple<string, string>> validatedResources = null)
         {
             var processor = new ProfilePreprocessor(profileResolutionNeeded, snapshotGenerationNeeded, instance, declaredTypeProfile, statedProfiles, statedCanonicals, Settings.ResourceMapping);
             var outcome = processor.Process();
 
             // Note: only start validating if the profiles are complete and consistent
             if (outcome.Success)
-                outcome.Add(Validate(instance, processor.Result));
+                outcome.Add(Validate(instance, processor.Result, validatedResources));
 
             return outcome;
 
@@ -157,29 +158,31 @@ namespace Hl7.Fhir.Validation
                 Settings.ResourceResolver?.FindStructureDefinition(canonical);
         }
 
-        internal OperationOutcome Validate(ITypedElement instance, ElementDefinitionNavigator definition)
+        internal OperationOutcome Validate(ITypedElement instance, ElementDefinitionNavigator definition, List<Tuple<string, string>> validatedResources = null)
         {
-            return Validate(instance, new[] { definition });
+            return Validate(instance, new[] { definition }, validatedResources);
         }
 
 
         // This is the one and only main internal entry point for all validations, which in its term
         // will call step 1 in the validator, the function validateElement
-        internal OperationOutcome Validate(ITypedElement elementNav, IEnumerable<ElementDefinitionNavigator> definitions)
+        internal OperationOutcome Validate(ITypedElement elementNav, IEnumerable<ElementDefinitionNavigator> definitions, List<Tuple<string, string>> validatedResources = null)
         {
             var outcome = new OperationOutcome();
 
-            var instance = elementNav as ScopedNode ?? new ScopedNode(elementNav);
+            BaseScopedNode instance = elementNav as ScopedNodeWrapper ?? new ScopedNodeWrapper(elementNav as ScopedNode ?? new ScopedNode(elementNav));
+
+            validatedResources = validatedResources ?? new List<Tuple<string, string>>();
 
             try
             {
-                var allDefinitions = definitions.ToList();
+                List<ElementDefinitionNavigator> allDefinitions = new List<ElementDefinitionNavigator>(definitions);
 
                 if (allDefinitions.Count() == 1)
-                    outcome.Add(validateElement(allDefinitions.Single(), instance));
+                    outcome.Add(validateElement(allDefinitions.Single(), instance, validatedResources));
                 else
                 {
-                    var validators = allDefinitions.Select(nav => createValidator(nav));
+                    var validators = allDefinitions.Select(nav => createValidator(nav, instance, validatedResources));
                     outcome.Add(this.Combine(BatchValidationMode.All, instance, validators));
                 }
             }
@@ -189,24 +192,24 @@ namespace Hl7.Fhir.Validation
             }
 
             return outcome;
-
-            Func<OperationOutcome> createValidator(ElementDefinitionNavigator nav) =>
-                () => validateElement(nav, instance);
-
         }
 
-        private OperationOutcome validateElement(ElementDefinitionNavigator definition, ScopedNode instance)
+
+        private Func<OperationOutcome> createValidator(ElementDefinitionNavigator nav, BaseScopedNode instance, List<Tuple<string, string>> validatedResources)
+        {
+            return () => validateElement(nav, instance, validatedResources);
+        }
+        
+        private OperationOutcome validateElement(ElementDefinitionNavigator definition, BaseScopedNode instance, List<Tuple<string, string>> validatedResources)
         {
             var outcome = new OperationOutcome();
-
+            
             // If navigator cannot be moved to content, there's really nothing to validate against.
             if (definition.AtRoot && !definition.MoveToFirstChild())
             {
                 outcome.AddIssue($"Snapshot component of profile '{definition.StructureDefinition?.Url}' has no content.", Issue.PROFILE_ELEMENTDEF_IS_EMPTY, instance);
                 return outcome;
             }
-
-            Trace(outcome, $"Start validation of ElementDefinition at path '{definition.CanonicalPath()}'", Issue.PROCESSING_PROGRESS, instance);
 
             // This does not work, since the children might still be empty, we need something better
             //// Any node must either have a value, or children, or both (e.g. extensions on primitives)
@@ -243,13 +246,13 @@ namespace Hl7.Fhir.Validation
                     // TODO: Check whether this is even true when the <type> has a profile?
                     // Note: the snapshot is *not* exhaustive if the declared type is a base FHIR type (like Resource),
                     // in which case there may be additional children (verified in the next step)
-                    outcome.Add(this.ValidateChildConstraints(definition, instance, allowAdditionalChildren: allowAdditionalChildren));
+                    outcome.Add(this.ValidateChildConstraints(definition, instance, allowAdditionalChildren: allowAdditionalChildren, validatedResources: validatedResources));
 
                     // Special case: if we are located at a nested resource (i.e. contained or Bundle.entry.resource),
                     // we need to validate based on the actual type of the instance
                     if (isInlineChildren && elementConstraints.IsResourcePlaceholder())
                     {
-                        outcome.Add(this.ValidateType(elementConstraints, instance));
+                        outcome.Add(this.ValidateType(elementConstraints, instance, validatedResources));
                     }
                 }
 
@@ -258,8 +261,8 @@ namespace Hl7.Fhir.Validation
                     // No inline-children, so validation depends on the presence of a <type> or <contentReference>
                     if (elementConstraints.Type != null || elementConstraints.ContentReference != null)
                     {
-                            outcome.Add(this.ValidateType(elementConstraints, instance));
-                            outcome.Add(ValidateNameReference(elementConstraints, definition, instance));
+                        outcome.Add(this.ValidateType(elementConstraints, instance, validatedResources));
+                        outcome.Add(ValidateNameReference(elementConstraints, definition, instance, validatedResources));
                     }
                     else
                         Trace(outcome, "ElementDefinition has no child, nor does it specify a type or contentReference to validate the instance data against", Issue.PROFILE_ELEMENTDEF_CONTAINS_NO_TYPE_OR_NAMEREF, instance);
@@ -349,8 +352,8 @@ namespace Hl7.Fhir.Validation
 
             try
             {
-                    Binding b = binding.ToValidatable();
-                    outcome.Add(b.Validate(instance, vc));
+                Binding b = binding.ToValidatable();
+                outcome.Add(b.Validate(instance, vc));
             }
             catch (IncorrectElementDefinitionException iede)
             {
@@ -360,7 +363,7 @@ namespace Hl7.Fhir.Validation
             return outcome;
         }
 
-        internal OperationOutcome ValidateNameReference(ElementDefinition definition, ElementDefinitionNavigator allDefinitions, ScopedNode instance)
+        internal OperationOutcome ValidateNameReference(ElementDefinition definition, ElementDefinitionNavigator allDefinitions, BaseScopedNode instance, List<Tuple<string, string>> validatedResources = null)
         {
             var outcome = new OperationOutcome();
 
@@ -371,7 +374,7 @@ namespace Hl7.Fhir.Validation
                 var referencedPositionNav = allDefinitions.ShallowCopy();
 
                 if (referencedPositionNav.JumpToNameReference(definition.ContentReference))
-                    outcome.Include(Validate(instance, referencedPositionNav));
+                    outcome.Include(Validate(instance, referencedPositionNav, validatedResources));
                 else
                     Trace(outcome, $"ElementDefinition uses a non-existing nameReference '{definition.ContentReference}'", Issue.PROFILE_ELEMENTDEF_INVALID_NAMEREFERENCE, instance);
 
@@ -453,8 +456,8 @@ namespace Hl7.Fhir.Validation
 
         private string toStringRepresentation(ITypedElement vp)
         {
-            return vp == null || vp.Value == null ? 
-                null : 
+            return vp == null || vp.Value == null ?
+                null :
                 PrimitiveTypeConverter.ConvertTo<string>(vp.Value);
         }
 


### PR DESCRIPTION
#465 
The check for circular references takes in consideration the profile and the reference as a pair. Had to adapt the IBucket to pass the list of validated references through the validation flow.
Simple unit test included.