### PR TITLE
Typo fix

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -51,7 +51,7 @@ namespace Hl7.Fhir.Specification.Tests
         //        GenerateSnapshot = true,
         //        EnableXsdValidation = true,
         //        Trace = false,
-        //        ResolveExteralReferences = true
+        //        ResolveExternalReferences = true
         //    };
 
         //    _validator = new Validator(ctx);
@@ -382,7 +382,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void DoNotFollowRefsSuppressesWarning()
         {
-            var validator = new Validator(new ValidationSettings { ResourceResolver = _source, ResolveExteralReferences = true });
+            var validator = new Validator(new ValidationSettings { ResourceResolver = _source, ResolveExternalReferences = true });
 
             Patient p = new Patient
             {
@@ -395,7 +395,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.Equal(1, result.Warnings);
             Assert.Contains("Cannot resolve reference http://reference.cannot.be.found.nl/fhir/Patient/1", result.Issue[0].ToString());
 
-            validator.Settings.ResolveExteralReferences = false;
+            validator.Settings.ResolveExternalReferences = false;
 
             result = validator.Validate(p);
             Assert.True(result.Success);
@@ -598,7 +598,7 @@ namespace Hl7.Fhir.Specification.Tests
                 GenerateSnapshot = false,
                 EnableXsdValidation = false,
                 Trace = false,
-                ResolveExteralReferences = true
+                ResolveExternalReferences = true
             };
 
             var validator = new Validator(ctx);
@@ -626,7 +626,7 @@ namespace Hl7.Fhir.Specification.Tests
             var bundle = (new FhirXmlParser()).Parse<Bundle>(bundleXml);
             Assert.NotNull(bundle);
 
-            var ctx = new ValidationSettings() { ResourceResolver = _source, GenerateSnapshot = true, ResolveExteralReferences = true, Trace = false };
+            var ctx = new ValidationSettings() { ResourceResolver = _source, GenerateSnapshot = true, ResolveExternalReferences = true, Trace = false };
             bool hitResolution = false;
 
             _validator = new Validator(ctx);
@@ -889,7 +889,7 @@ namespace Hl7.Fhir.Specification.Tests
                 GenerateSnapshot = true,
                 EnableXsdValidation = true,
                 Trace = false,
-                ResolveExteralReferences = true
+                ResolveExternalReferences = true
             };
 
             var validator = new Validator(ctx);
@@ -932,7 +932,7 @@ namespace Hl7.Fhir.Specification.Tests
                 GenerateSnapshot = true,
                 EnableXsdValidation = true,
                 Trace = false,
-                ResolveExteralReferences = true
+                ResolveExternalReferences = true
             };
 
             return new Validator(ctx);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.Specification.Tests
                 GenerateSnapshot = true,
                 EnableXsdValidation = true,
                 Trace = false,
-                ResolveExteralReferences = true
+                ResolveExternalReferences = true
             };
 
 

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -131,7 +131,7 @@ namespace Hl7.Fhir.Validation
                 validator.Trace(outcome, $"Encountered a reference ({reference}) of kind '{encounteredKind}' which is not allowed", Issue.CONTENT_REFERENCE_OF_INVALID_KIND, instance);
 
             // Bail out if we are asked to follow an *external reference* when this is disabled in the settings
-            if (validator.Settings.ResolveExteralReferences == false && encounteredKind == ElementDefinition.AggregationMode.Referenced)
+            if (validator.Settings.ResolveExternalReferences == false && encounteredKind == ElementDefinition.AggregationMode.Referenced)
                 return outcome;
 
             // If we failed to find a referenced resource within the current instance, try to resolve it using an external method

--- a/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
@@ -82,7 +82,10 @@ namespace Hl7.Fhir.Validation
         /// external reference. Note: References that refer to resources inside the current instance (i.e.
         /// contained resources, Bundle entries) will always be followed and validated.
         /// </summary>
-        public bool ResolveExteralReferences { get; set; } // = false;
+        public bool ResolveExternalReferences { get; set; } // = false;
+
+        [Obsolete("Typo. Please use the correct ResolveExternalReferences property")]
+        public bool ResolveExteralReferences { get { return ResolveExternalReferences; } set { ResolveExternalReferences = value; } }
 
         /// <summary>
         /// If set to true (and the XDocument specific overloads of validate() are used), the validator will run
@@ -111,7 +114,7 @@ namespace Hl7.Fhir.Validation
             other.GenerateSnapshot = GenerateSnapshot;
             other.GenerateSnapshotSettings = GenerateSnapshotSettings?.Clone();
             other.EnableXsdValidation = EnableXsdValidation;
-            other.ResolveExteralReferences = ResolveExteralReferences;
+            other.ResolveExternalReferences = ResolveExternalReferences;
             other.ResourceResolver = ResourceResolver;
             other.SkipConstraintValidation = SkipConstraintValidation;
             other.TerminologyService = TerminologyService;

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -460,7 +460,7 @@ namespace Hl7.Fhir.Validation
 
         internal ITypedElement ExternalReferenceResolutionNeeded(string reference, OperationOutcome outcome, string path)
         {
-            if (!Settings.ResolveExteralReferences) return null;
+            if (!Settings.ResolveExternalReferences) return null;
 
             try
             {


### PR DESCRIPTION
#961 
<ResolveExternalReferences> instead of <ResolveExteralReferences>

<ResolveExteralReferences> is now marked as obsolete.