### PR TITLE
Improvement: 1169 Setting Code property performance

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/CodeEnumTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/CodeEnumTests.cs
@@ -16,6 +16,7 @@ using System.Xml.Linq;
 using System.ComponentModel.DataAnnotations;
 using Hl7.Fhir.Validation;
 using Hl7.Fhir.Utility;
+using System.Diagnostics;
 
 namespace Hl7.Fhir.Tests.Model
 {
@@ -69,11 +70,27 @@ namespace Hl7.Fhir.Tests.Model
             Assert.IsNull(c.System);
         }
 
+        [TestMethod]
+        public void TestCodeAssignementPerformance()
+        {
+            var patient = new Patient();
+            patient.Gender = Hl7.Fhir.Model.AdministrativeGender.Female;
+            var watch = Stopwatch.StartNew();
+            const int count = 10_000;
+            for (var i = 0; i < count; i++)
+            {
+                patient.Gender = Hl7.Fhir.Model.AdministrativeGender.Female;
+                //patient.Active = false;
+            }
+            watch.Stop();
+            Debug.WriteLine("Set code X {0:N0}: {1:N1} msec", count, watch.ElapsedMilliseconds);
+        }
+
+
         [FhirEnumeration("TestEnum")]
         private enum TestEnum
         {
             IHaveNoSystem = 4
         }
-
     }
 }


### PR DESCRIPTION
#1169 
Added a unit test for the performance of Code properties that use Enum literals. Debug only.

Actual fix: https://github.com/FirelyTeam/fhir-net-common/pull/15