### PR TITLE
Fix: now trims whitespaces of value attributes when serializing to xml

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -254,11 +254,16 @@ namespace Hl7.Fhir.Tests.Serialization
                 }
             };
 
-            var xml = FhirXmlSerializer.SerializeToString(patient);
+            var trimmed = FhirXmlSerializer.SerializeToString(patient);
+            Assert.IsFalse(trimmed.Contains(" Smith"));
+            Assert.IsFalse(trimmed.Contains("Smith&#xD;&#xA;&#x9;"));
+            Assert.IsTrue(trimmed.Contains("\"Smith\""));
 
-            Assert.IsFalse(xml.Contains(" Smith"));
-            Assert.IsFalse(xml.Contains("Smith&#xD;&#xA;&#x9;"));
-            Assert.IsTrue(xml.Contains("\"Smith\""));
+            var notTrimmed = new FhirXmlSerializer(new SerializerSettings { TrimWhiteSpacesInXml = false }).SerializeToString(patient);
+            Assert.IsTrue(notTrimmed.Contains(" Smith"));
+            Assert.IsTrue(notTrimmed.Contains("Smith&#xD;&#xA;&#x9;"));
+            Assert.IsFalse(notTrimmed.Contains("\"Smith\""));
+
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -244,6 +244,24 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
+        public void TestSerializeWhitespacesInXml()
+        {
+            var patient = new Patient
+            {
+                Name = new List<HumanName>
+                {
+                    new HumanName { Family = " Smith\r\n\t" }
+                }
+            };
+
+            var xml = FhirXmlSerializer.SerializeToString(patient);
+
+            Assert.IsFalse(xml.Contains(" Smith"));
+            Assert.IsFalse(xml.Contains("Smith&#xD;&#xA;&#x9;"));
+            Assert.IsTrue(xml.Contains("\"Smith\""));
+        }
+
+        [TestMethod]
         public void TryScriptInject()
         {
             var x = new Patient();
@@ -252,7 +270,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             var xml = FhirXmlSerializer.SerializeToString(x);
             Assert.IsFalse(xml.Contains("<script"));
-        }
+        }       
 
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Serialization
         }
 
         private FhirXmlSerializationSettings buildFhirXmlWriterSettings() =>
-            new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
+            new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhitespaces = Settings.TrimWhiteSpacesInXml };
 
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) => 
             MakeElementStack(instance, summary, elements)

--- a/src/Hl7.Fhir.Core/Serialization/SerializerSettings.cs
+++ b/src/Hl7.Fhir.Core/Serialization/SerializerSettings.cs
@@ -24,6 +24,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool AppendNewLine { get; set; } // = false;
 
+        /// <summary>
+        /// Trim whitespaces at the beginning and end of xml attribute value
+        /// </summary>
+        public bool TrimWhiteSpacesInXml { get; set; } = true;
+
         /// <summary>Default constructor. Creates a new <see cref="SerializerSettings"/> instance with default property values.</summary>
         public SerializerSettings() { }
 
@@ -44,6 +49,7 @@ namespace Hl7.Fhir.Serialization
 
             other.Pretty = Pretty;
             other.AppendNewLine = AppendNewLine;
+            other.TrimWhiteSpacesInXml = TrimWhiteSpacesInXml;
         }
 
         /// <summary>Creates a new <see cref="SerializerSettings"/> object that is a copy of the current instance.</summary>


### PR DESCRIPTION
https://github.com/FirelyTeam/fhir-net-api/issues/1176 
