### PR TITLE
Bugfix/1189 xml representation mapping

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
@@ -185,7 +185,7 @@ namespace Hl7.Fhir.Serialization.Tests
             foreach(var element in testElements)
             {
                 var representation = summaryElements.Where(e => e.ElementName == element.ToString()).FirstOrDefault().Representation;
-                if (!representation.ToString().Equals(element.ToString()))
+                if (!representation.Equals(element))
                 {
                     Assert.Fail("Respresentation is expected to be the same as the name of the test element");
                 }

--- a/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
@@ -175,5 +175,21 @@ namespace Hl7.Fhir.Serialization.Tests
             }
 
         }
+
+        public static void TestXmlRepresetation(IStructureDefinitionSummaryProvider provider)
+        {
+            var testElements = new XmlRepresentation[] { XmlRepresentation.XmlAttr, XmlRepresentation.TypeAttr, XmlRepresentation.XHtml }; // Elements defined by TestXmlRepresentation (Logical Model)
+            var summary = provider.Provide("http://hl7.org/fhir/StructureDefinition/TestXmlRepresentation");
+            var summaryElements = summary.GetElements();
+
+            foreach(var element in testElements)
+            {
+                var representation = summaryElements.Where(e => e.ElementName == element.ToString()).FirstOrDefault().Representation;
+                if (!representation.ToString().Equals(element.ToString()))
+                {
+                    Assert.Fail("Respresentation is expected to be the same as the name of the test element");
+                }
+            }
+        }
     }
 }

--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
@@ -11,7 +11,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [ClassInitialize]
         public static void SetupSource(TestContext t)
         {
-            source = new MultiResolver(ZipSource.CreateValidationSource(), new DirectorySource("TestData", includeSubdirectories: true));
+            source = new MultiResolver(ZipSource.CreateValidationSource(), new DirectorySource("TestData", new DirectorySourceSettings(includeSubdirectories: true)));
         }
 
         static IResourceResolver source = null;

--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
@@ -11,7 +11,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [ClassInitialize]
         public static void SetupSource(TestContext t)
         {
-            source = ZipSource.CreateValidationSource();
+            source = new MultiResolver(ZipSource.CreateValidationSource(), new DirectorySource("TestData", includeSubdirectories: true));
         }
 
         static IResourceResolver source = null;
@@ -30,6 +30,9 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         public void TestValueIsNotAChild() => SerializationInfoTestHelpers.TestValueIsNotAChild(new StructureDefinitionSummaryProvider(source));
+
+        [TestMethod]
+        public void TestXmlRepresetation() => SerializationInfoTestHelpers.TestXmlRepresetation(new StructureDefinitionSummaryProvider(source));
 
     }
 }

--- a/src/Hl7.Fhir.Specification.Tests/TestData/TestXmlRepresentation.StructureDefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/TestXmlRepresentation.StructureDefinition.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="http://example.org/fhir/StructureDefinition/TestXmlRepresentation" />
+  <name value="TestXmlRepresentation" />
+  <status value="draft" />
+  <fhirVersion value="4.0.0" />
+  <kind value="logical" />
+  <abstract value="false" />
+  <type value="http://example.org/fhir/StructureDefinition/TestXmlRepresentation" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Element" />
+  <derivation value="specialization" />
+  <differential>
+    <element id="TestXmlRepresentation">
+      <path value="TestXmlRepresentation" />
+      <min value="0" />
+      <max value="*" />
+      <type>
+        <code value="Element" />
+      </type>
+    </element>
+    <element id="TestXmlRepresentation.xmlAttr">
+      <path value="TestXmlRepresentation.xmlAttr" />
+      <representation value="xmlAttr" />
+      <min value="0" />
+      <max value="*" />
+      <type>
+        <code value="string" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/string" />
+      </type>
+    </element>
+    <element id="TestXmlRepresentation.typeAttr">
+      <path value="TestXmlRepresentation.typeAttr" />
+      <representation value="typeAttr" />
+      <min value="0" />
+      <max value="*" />
+      <type>
+        <code value="string" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/string" />
+      </type>
+    </element>
+    <element id="TestXmlRepresentation.xhtml">
+      <path value="TestXmlRepresentation.xhtml" />
+      <representation value="xhtml" />
+      <min value="0" />
+      <max value="*" />
+      <type>
+        <code value="xhtml" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/xhtml" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/summary-test/TestXmlRepresentation.StructureDefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/summary-test/TestXmlRepresentation.StructureDefinition.xml
@@ -1,25 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <url value="http://example.org/fhir/StructureDefinition/TestXmlRepresentation" />
+  <url value="http://hl7.org/fhir/StructureDefinition/TestXmlRepresentation" />
   <name value="TestXmlRepresentation" />
   <status value="draft" />
   <fhirVersion value="4.0.0" />
   <kind value="logical" />
   <abstract value="false" />
-  <type value="http://example.org/fhir/StructureDefinition/TestXmlRepresentation" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Element" />
+  <type value="TestXmlRepresentation" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DomainResource" />
   <derivation value="specialization" />
-  <differential>
+  <snapshot>
     <element id="TestXmlRepresentation">
       <path value="TestXmlRepresentation" />
       <min value="0" />
       <max value="*" />
-      <type>
-        <code value="Element" />
-      </type>
     </element>
-    <element id="TestXmlRepresentation.xmlAttr">
-      <path value="TestXmlRepresentation.xmlAttr" />
+    <element id="TestXmlRepresentation.XmlAttr">
+      <path value="TestXmlRepresentation.XmlAttr" />
       <representation value="xmlAttr" />
       <min value="0" />
       <max value="*" />
@@ -28,8 +25,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/string" />
       </type>
     </element>
-    <element id="TestXmlRepresentation.typeAttr">
-      <path value="TestXmlRepresentation.typeAttr" />
+    <element id="TestXmlRepresentation.TypeAttr">
+      <path value="TestXmlRepresentation.TypeAttr" />
       <representation value="typeAttr" />
       <min value="0" />
       <max value="*" />
@@ -38,8 +35,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/string" />
       </type>
     </element>
-    <element id="TestXmlRepresentation.xhtml">
-      <path value="TestXmlRepresentation.xhtml" />
+    <element id="TestXmlRepresentation.XHtml">
+      <path value="TestXmlRepresentation.XHtml" />
       <representation value="xhtml" />
       <min value="0" />
       <max value="*" />
@@ -48,5 +45,5 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/xhtml" />
       </type>
     </element>
-  </differential>
+  </snapshot>
 </StructureDefinition>

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -216,6 +216,14 @@ namespace Hl7.Fhir.Specification
                 {
                     case ElementDefinition.PropertyRepresentation.XmlAttr:
                         return XmlRepresentation.XmlAttr;
+                    case ElementDefinition.PropertyRepresentation.XmlText:
+                        return XmlRepresentation.XmlText;
+                    case ElementDefinition.PropertyRepresentation.TypeAttr:
+                        return XmlRepresentation.TypeAttr;
+                    case ElementDefinition.PropertyRepresentation.CdaText:
+                        return XmlRepresentation.CdaText;
+                    case ElementDefinition.PropertyRepresentation.Xhtml:
+                        return XmlRepresentation.XHtml;
                     default:
                         return XmlRepresentation.XmlElement;
                 }


### PR DESCRIPTION
Adjust StructureDefinitionSummaryProvider to return a complete mapping of ElementDefinition.representation.

Fixes #1189