### PR TITLE
fix: Multiple includes throws exception

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -788,6 +788,26 @@ namespace Hl7.Fhir.Tests.Rest
             }
         }
 
+        [TestMethod]
+        [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        public void TestSearchUsingPostMultipleIncludesShouldNotThrowArgumentException()
+        {
+            // This test case proves issue https://github.com/FirelyTeam/fhir-net-api/issues/1206 is fixed. 
+            // Previoulsly EntryToHttpExtensions.setBodyAndContentType used a Dictionary which required the 
+            // name part of the parameters to be unique.
+            // Fixed by using IEnumerable<KeyValuePair<string, string>> instead of Dictionary<string, string>
+            var client = new FhirClient(testEndpoint);
+
+            var sp = new SearchParams();
+            sp.Parameters.Add(new Tuple<string, string>("_id", "8465,8479"));
+            sp.Include.Add("subject");
+
+            // Add a further include
+            sp.Include.Add("encounter");
+
+            client.SearchUsingPost<Procedure>(sp);
+        }
+
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]

--- a/src/Hl7.Fhir.Core/Rest/EntryToHttpExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/EntryToHttpExtensions.cs
@@ -155,10 +155,10 @@ namespace Hl7.Fhir.Rest
             }
             else if (searchUsingPost)
             {
-                IDictionary<string, string> bodyParameters = new Dictionary<string, string>();
-                foreach(Parameters.ParameterComponent parameter in ((Parameters)data).Parameter)
+                var bodyParameters = new List<KeyValuePair<string, string>>();
+                foreach (Parameters.ParameterComponent parameter in ((Parameters)data).Parameter)
                 {
-                    bodyParameters.Add(parameter.Name, parameter.Value.ToString());
+                    bodyParameters.Add(new KeyValuePair<string, string>(parameter.Name, parameter.Value.ToString()));
                 }
                 if (bodyParameters.Count > 0)
                 {


### PR DESCRIPTION
* Using IEnumerable<KeyValuePair<string, string>> instead of Dictionary
  in EntryToHttpExtensions.setBodyAndContentType
* Fixes #1206