### PR TITLE
Feature/new 1208 xhtml in ccda

### DIFF
--- a/src/Hl7.Fhir.ElementModel.Tests/Hl7.Fhir.ElementModel.Tests.csproj
+++ b/src/Hl7.Fhir.ElementModel.Tests/Hl7.Fhir.ElementModel.Tests.csproj
@@ -41,4 +41,7 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestData\TestSd\" />
+  </ItemGroup>
 </Project>

--- a/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
@@ -1,5 +1,8 @@
 ﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
+using Hl7.Fhir.Specification.Snapshot;
+using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -186,38 +189,6 @@ namespace Hl7.Fhir.ElementModel.Tests
         }
 
         [TestMethod]
-        public void ITypedElementFromLogicalModelHasChildrenDefinition()
-        {
-
-            bool CCDATypeNameMapper(string typeName, out string canonical)
-            {
-                if (ModelInfo.IsPrimitive(typeName))
-                    canonical = "http://hl7.org/fhir/StructureDefinition/" + typeName;
-                else
-                    canonical = "http://hl7.org/fhir/cda/StructureDefinition/" + typeName;
-
-                return true;
-            }
-
-            var ccdaInstanceXml = File.ReadAllText(Path.Combine("TestData", "CCDA_Instance_Example.xml"));
-            var ccdaNode = FhirXmlNode.Parse(ccdaInstanceXml);
-
-            var summaryProvider = new StructureDefinitionSummaryProvider(new CCDAResourceResolver(), CCDATypeNameMapper);
-
-            var typedElement = ccdaNode.ToTypedElement(summaryProvider);
-            Assert.IsNotNull(typedElement);
-
-            var error = typedElement.VisitAndCatch();
-
-            Console.WriteLine("Test");
-
-            // realmCode
-            // id
-            // title
-            // languageCode
-        }
-
-        [TestMethod]
         public void CcdaWithXhtmlTag()
         {
             bool CCDATypeNameMapper(string typeName, out string canonical)
@@ -242,11 +213,7 @@ namespace Hl7.Fhir.ElementModel.Tests
 
             Assert.IsTrue(!errors.Any());
 
-            var assertXHtml = typedElement.Children("component").First().
-                Children("structuredBody").First().
-                Children("component").First().
-                Children("section").First().
-                Children("text");
+            var assertXHtml = typedElement.Children("text");
 
             Assert.IsNotNull(assertXHtml);
             Assert.AreEqual(1, assertXHtml.Count());
@@ -268,7 +235,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             {
                 _cache = new Dictionary<string, StructureDefinition>();
                 _zipSource = new ZipSource("specification.zip");
-                _coreResolver = new CachedResolver(new MultiResolver(_zipSource, new DirectorySource("TestData/ccda")));
+                _coreResolver = new CachedResolver(new MultiResolver(_zipSource, new DirectorySource("TestData/TestSd")));
             }
 
             public Resource ResolveByCanonicalUri(string uri)

--- a/src/Hl7.Fhir.ElementModel.Tests/TestData/CCDA_With_Xhtml_Tag.xml
+++ b/src/Hl7.Fhir.ElementModel.Tests/TestData/CCDA_With_Xhtml_Tag.xml
@@ -1,51 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="CDA.xsl"?>
-<ClinicalDocument 
-  xmlns="urn:hl7-org:v3" 
-  xmlns:sdtc="urn:hl7-org:sdtc" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <component>
-        <structuredBody>
-            <component>
-                <section>
-                    <text>
-                        <table border="1" width="100%">
-                            <colgroup>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                                <col width="14%"/>
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Normalized Allergy Type</th>
-                                    <th>Allergy classification</th>
-                                    <th>Reported allergen</th>
-                                    <th>Date of Allergy Onset</th>
-                                    <th>Reaction(s)</th>
-                                    <th>Care Provider</th>
-                                    <th>Facility</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr ID="allergies00001">
-                                    <td>Drug Allergy (2 sources.)</td>
-                                    <td>NSAIDs</td>
-                                    <td ID="allergies00001value">NSAIDs</td>
-                                    <td>05-10-2014 -</td>
-                                    <td>rash, nausea and vomiting</td>
-                                    <td>Phil Wellington 62781</td>
-                                    <td>Emergency Room (27710) (Work Phone: (555)555-5000)</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <h1>test</h1>
-                    </text>
-                </section>
-            </component>
-        </structuredBody>
-    </component>
-</ClinicalDocument>
+<Section>
+    <text>
+        <table border="1" width="100%">
+            <colgroup>
+                <col width="14%" />
+                <col width="14%" />
+                <col width="14%" />
+                <col width="14%" />
+                <col width="14%" />
+                <col width="14%" />
+                <col width="14%" />
+            </colgroup>
+            <thead>
+                <tr>
+                    <th>Normalized Allergy Type</th>
+                    <th>Allergy classification</th>
+                    <th>Reported allergen</th>
+                    <th>Date of Allergy Onset</th>
+                    <th>Reaction(s)</th>
+                    <th>Care Provider</th>
+                    <th>Facility</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ID="allergies00001">
+                    <td>Drug Allergy (2 sources.)</td>
+                    <td>NSAIDs</td>
+                    <td ID="allergies00001value">NSAIDs</td>
+                    <td>05-10-2014 -</td>
+                    <td>rash, nausea and vomiting</td>
+                    <td>Phil Wellington 62781</td>
+                    <td>Emergency Room (27710) (Work Phone: (555)555-5000)</td>
+                </tr>
+            </tbody>
+        </table>
+        <h1>test</h1>
+    </text>
+</Section>

--- a/src/Hl7.Fhir.ElementModel.Tests/TestData/CCDA_With_Xhtml_Tag.xml
+++ b/src/Hl7.Fhir.ElementModel.Tests/TestData/CCDA_With_Xhtml_Tag.xml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="CDA.xsl"?>
+<ClinicalDocument 
+  xmlns="urn:hl7-org:v3" 
+  xmlns:sdtc="urn:hl7-org:sdtc" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <text>
+                        <table border="1" width="100%">
+                            <colgroup>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                                <col width="14%"/>
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Normalized Allergy Type</th>
+                                    <th>Allergy classification</th>
+                                    <th>Reported allergen</th>
+                                    <th>Date of Allergy Onset</th>
+                                    <th>Reaction(s)</th>
+                                    <th>Care Provider</th>
+                                    <th>Facility</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="allergies00001">
+                                    <td>Drug Allergy (2 sources.)</td>
+                                    <td>NSAIDs</td>
+                                    <td ID="allergies00001value">NSAIDs</td>
+                                    <td>05-10-2014 -</td>
+                                    <td>rash, nausea and vomiting</td>
+                                    <td>Phil Wellington 62781</td>
+                                    <td>Emergency Room (27710) (Work Phone: (555)555-5000)</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <h1>test</h1>
+                    </text>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/Hl7.Fhir.ElementModel.Tests/TestData/TestSd/Section.xml
+++ b/src/Hl7.Fhir.ElementModel.Tests/TestData/TestSd/Section.xml
@@ -1,0 +1,27 @@
+﻿<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="Section"/>
+    <url value="http://hl7.org/fhir/cda/StructureDefinition/Section"/>
+    <name value="CDAR2.Section"/>
+    <title value="Section (CDA Class)"/>
+    <status value="active"/>
+    <experimental value="true"/>
+    <kind value="logical"/>
+    <type value="Section"/>
+    <differential>
+        <element id="Section">
+            <path value="Section"/>
+            <min value="1"/>
+            <max value="1"/>
+        </element>
+        <element id="Section.text">
+            <path value="Section.text"/>
+            <representation value="cdaText"/>
+            <min value="0"/>
+            <max value="1"/>
+            <type>
+                <code value="xhtml"/>
+            </type>
+            <mustSupport value="true"/>
+        </element>
+    </differential>
+</StructureDefinition>


### PR DESCRIPTION
IssueNumber 1208

Opened a new PR with a new branch with the right basebranch. 

With this feature the ccda tags with a xhtml type will be translated to one node in ITypedelement. They will be still in a tree structure after parsing to an ISourceNode type! The Logic is implemented, so that the normal FHIR procedures are not effected and the new logic only works with ccda/xhtml nodes.
