### PR TITLE
Bugfix/1200 conditional update is not url encoding spaces in searchparameters

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/TransactionBuilderTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/TransactionBuilderTests.cs
@@ -33,6 +33,22 @@ namespace Hl7.Fhir.Test
             var e = b.Entry[0];
 
             Assert.AreEqual(relativeEscapedUrl, e.Request.Url);
+
+
+            var relativeEscapedUrl2 = "Location?name=Enc%C3%B6ding%20T%C3%A9st";
+            var location = new Location
+            {
+                Name = "Encöding Tést",
+            };
+
+            var trxBuilder = new TransactionBuilder("http://example.org/test/fhir", Bundle.BundleType.Transaction);
+            var cond = new SearchParams()
+                .Add("name", location.Name);
+
+            var b2 = trxBuilder.Update(cond, location).ToBundle();
+            var e2 = b2.Entry[0];
+
+            Assert.AreEqual(relativeEscapedUrl2, e2.Request.Url);            
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core/Rest/TransactionBuilder.cs
+++ b/src/Hl7.Fhir.Core/Rest/TransactionBuilder.cs
@@ -66,7 +66,8 @@ namespace Hl7.Fhir.Rest
 
         private void addEntry(Bundle.EntryComponent newEntry, RestUrl path)
         {
-            newEntry.Request.Url = HttpUtil.MakeRelativeFromBase(path.Uri, _baseUrl).ToString();
+            var url = HttpUtil.MakeRelativeFromBase(path.Uri, _baseUrl);
+            newEntry.Request.Url = url.OriginalString;
             _result.Entry.Add(newEntry);
         }
 


### PR DESCRIPTION
#1200 Apparently creating the URI unescapes "Encöding Tést".

This is fixed by asking for the string that was passed to the constructing when creating the URI, instead of the ToString() method that unescapes it.
