### PR TITLE
Fix/1229 snapshot generator slicing discriminator

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
@@ -19,7 +19,9 @@
 
   
   <ItemGroup>
+      <PackageReference Include="FluentAssertions" Version="5.4.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+      <PackageReference Include="Moq" Version="4.13.1" />
       <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
       <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
       <PackageReference Include="System.IO.Compression" Version="4.3.0" />

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -74,7 +74,7 @@ namespace Hl7.Fhir.Specification.Tests
             return new StructureDefinition
             {
                 Url = url,
-                Name = "bla",
+                Name = "name",
                 Status = PublicationStatus.Draft,
                 Kind = StructureDefinition.StructureDefinitionKind.Resource,
                 Abstract = false,
@@ -89,7 +89,11 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void OverriddenNestedStructureDefinitionLists()
         {
-            var baseSD = CreateStructureDefinition("http://bla",
+            var baseCanonical = "http://yourdomain.org/fhir/StructureDefinition/Base";
+            var code = "someCode";
+            var discriminatorPath = "system";
+
+            var baseSD = CreateStructureDefinition(baseCanonical,
                 new ElementDefinition
                 {
                     Path = "Practitioner.identifier",
@@ -101,7 +105,7 @@ namespace Hl7.Fhir.Specification.Tests
                             new ElementDefinition.DiscriminatorComponent
                             {
                                 Type = ElementDefinition.DiscriminatorType.Value,
-                                Path = "system"
+                                Path = discriminatorPath
                             }
                         }
                     }
@@ -110,14 +114,14 @@ namespace Hl7.Fhir.Specification.Tests
                 {
                     Path = "Practitioner.identifier:test",
                     SliceName = "test",
-                    Condition = new[] { "bla" },
+                    Condition = new[] { "http://system.org" },
                     Code = new List<Coding>
                     {
-                        new Coding{Code = "blu"}
+                        new Coding{Code = code}
                     }
                 });
 
-            var derivedSD = CreateStructureDefinition("http://bli",
+            var derivedSD = CreateStructureDefinition("http://yourdomain.org/fhir/StructureDefinition/Derived",
                 new ElementDefinition
                 {
                     Path = "Practitioner.identifier",
@@ -137,8 +141,8 @@ namespace Hl7.Fhir.Specification.Tests
             var snapshotGenerator = new SnapshotGenerator(resourceResolver.Object, new SnapshotGeneratorSettings());
             snapshotGenerator.Update(derivedSD);
 
-            derivedSD.Snapshot.Element.Single(element => element.Path == "Practitioner.identifier").Slicing.Discriminator.First().Path.Should().Be("system", "The discriminator should be copied from base");
-            derivedSD.Snapshot.Element.Single(element => element.Path == "Practitioner.identifier:test").Code.First().Code.Should().Be("blu", "The code should be copied from base");
+            derivedSD.Snapshot.Element.Single(element => element.Path == "Practitioner.identifier").Slicing.Discriminator.First().Path.Should().Be(discriminatorPath, "The discriminator should be copied from base");
+            derivedSD.Snapshot.Element.Single(element => element.Path == "Practitioner.identifier:test").Code.First().Code.Should().Be(code, "The code should be copied from base");
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -166,7 +166,10 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 snap.Binding = mergeComplexAttribute(snap.Binding, diff.Binding);
 
+                // [AE 20200129] Merging only fails for lists on a nested level. Slicing.Discriminator is the only case where this happens
+                var originalDiscriminator = snap.Slicing?.Discriminator;
                 snap.Slicing = mergeComplexAttribute(snap.Slicing, diff.Slicing);
+                CorrectListMerge(originalDiscriminator, diff.Slicing?.Discriminator, list => snap.Slicing.Discriminator = list);
 
                 // [WMR 20160817] TODO: Merge extensions
                 // Debug.WriteLineIf(diff.Extension != null && diff.GetChangedByDiff() == null, "[ElementDefnMerger] Warning: Extension merging is not supported yet...");
@@ -177,6 +180,15 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // [EK 20170301] Added this after comparison with Java generated snapshot
                 snap.RepresentationElement = mergeCollection(snap.RepresentationElement, diff.RepresentationElement, (s, d) => s.IsExactly(d));
+            }
+
+            private void CorrectListMerge<T>(List<T> originalBase, List<T> replacement, Action<List<T>> setBase)
+            {
+                if (replacement is List<T> list && !list.Any())
+                {
+                    // list has been replaced inadvertently. Change it back
+                    setBase(originalBase);
+                }
             }
 
             /// <summary>Notify clients about a snapshot element with differential constraints.</summary>


### PR DESCRIPTION
Fix for issue #1229 . The issue suggests we can also solve this in the CopyTo POCO method, but since this happens only on ElementDef.Slicing.Discriminator, I fixed this using a workaround for now
I also included a unit test, which uses Moq. I didnt see an alternative, but I could be wrong. Please let me know if thats the case
