### PR TITLE
fix: check explicitly for Resource.id in buildTypes of the sd summary…

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Element.cs
+++ b/src/Hl7.Fhir.Core/Model/Element.cs
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Model
         /// <summary>
         /// xml:id (or equivalent in JSON)
         /// </summary>
-        [FhirElement("id", XmlSerialization = XmlRepresentation.XmlAttr, InSummary = true, Order = 10, TypeRedirect = typeof(Id))]
+        [FhirElement("id", XmlSerialization = XmlRepresentation.XmlAttr, InSummary = true, Order = 10, TypeRedirect = typeof(FhirString))]
         [DataMember]
         public string ElementId
         {

--- a/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
@@ -141,7 +141,7 @@ namespace Hl7.Fhir.Serialization.Tests
             checkType(div, "div", false, "xhtml");
 
             // Element.id
-            checkType(div, "id", false, "id");
+            checkType(div, "id", false, "string");
 
             var ext = provider.Provide("Extension");
 

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -197,14 +197,19 @@ namespace Hl7.Fhir.Specification
                 return new[] { (ITypeSerializationInfo)new TypeReferenceInfo("uri") };
             }
             else
-            {
-                if (nav.Current.Type[0].GetExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")?.Value is FhirUrl url)
+            {                
+                var basePath = nav.Current?.Base?.Path;
+                if (basePath == "Resource.id")
                 {
                     // [MV 20191217] it should be url?.Value, but there is something wrong in the 
                     // specification (https://jira.hl7.org/browse/FHIR-25262), so I manually change it to "id".
                     //return new[] { (ITypeSerializationInfo)new TypeReferenceInfo(url?.Value) };
 
                     return new[] { (ITypeSerializationInfo)new TypeReferenceInfo("id") };
+                }
+                else if (nav.Current.Type[0].GetExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")?.Value is FhirUrl url)
+                {
+                    return new[] { (ITypeSerializationInfo)new TypeReferenceInfo(url?.Value) };
                 }
                 else
                     return nav.Current.Type.Select(t => (ITypeSerializationInfo)new TypeReferenceInfo(t.Code)).Distinct().ToArray();


### PR DESCRIPTION
#1233 

Added extra check for Resource.id and changed TypeRedirect of Element.id from "Id" to "FhirString"
