### PR TITLE
fix: change  TypeRedirect on element id from "Id" to "FhirString" and re-enabled unit test

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Element.cs
+++ b/src/Hl7.Fhir.Core/Model/Element.cs
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Model
         /// <summary>
         /// xml:id (or equivalent in JSON)
         /// </summary>
-        [FhirElement("id", XmlSerialization = XmlRepresentation.XmlAttr, InSummary = true, Order = 10, TypeRedirect = typeof(Id))]
+        [FhirElement("id", XmlSerialization = XmlRepresentation.XmlAttr, InSummary = true, Order = 10, TypeRedirect = typeof(FhirString))]
         [DataMember]
         public string ElementId
         {

--- a/src/Hl7.Fhir.Specification.Tests/PocoSerializationInfoTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/PocoSerializationInfoTests.cs
@@ -22,8 +22,6 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public void TestCanGetElements() => SerializationInfoTestHelpers.TestCanGetElements(new PocoStructureDefinitionSummaryProvider());
 
-
-        [Ignore("What would be the type of element.id? Needs more research: ")]
         [TestMethod]
         public void TestSpecialTypes() => SerializationInfoTestHelpers.TestSpecialTypes(new PocoStructureDefinitionSummaryProvider());
 


### PR DESCRIPTION
#1233 
element.id changes in R5