### PR TITLE
fix: skip interfaces in getting baseDefinitions in snapshot generation

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -2381,8 +2381,7 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandResource(@"http://hl7.org/fhir/StructureDefinition/Extension");
         }
 
-        // [WMR 20190130] DEBUGGING
-        [Ignore("[MV 20200129] Difference in Questionnaire.text and DomainResource.text. TODO")]
+        // [WMR 20190130] DEBUGGING        
         [TestMethod]
         public void TestExpandQuestionnaireResource()
         {
@@ -2390,7 +2389,7 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandResource(@"http://hl7.org/fhir/StructureDefinition/Questionnaire");
         }
 
-        [Ignore("[MV 20200129] Differences found. TODO")]
+    
         [TestMethod]
         public void TestExpandCoreArtifacts()
         {
@@ -2427,7 +2426,6 @@ namespace Hl7.Fhir.Specification.Tests
             testExpandResources(coreTypeUrls.ToArray());
         }
 
-        [Ignore("[MV 20200129] Differences found. TODO")]
         [TestMethod]
         [TestCategory("LongRunner")]
         public void TestExpandAllCoreResources()
@@ -2621,7 +2619,11 @@ namespace Hl7.Fhir.Specification.Tests
                     // [WMR 20190131] Fixed
                     var baseDef = expanded.BaseDefinition;
                     bool isDerivedFromResource = baseDef == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Resource);
-                    bool isDerivedFromDomainResource = baseDef == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource);
+                    // [MS 20200130] Added new base definitions MetadataResource and CanonicalResource
+                    bool isDerivedFromDomainResource =  (baseDef == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource).ToString() 
+                                                        || baseDef == "http://hl7.org/fhir/StructureDefinition/MetadataResource" 
+                                                        || baseDef == "http://hl7.org/fhir/StructureDefinition/CanonicalResource");
+
                     bool isDomainResource = expanded.Name == "DomainResource";
 
                     // [WMR 20190130] STU3

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -286,7 +286,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 }
 
                 // [MMS 20200203] Skip interface structures while looking for base profile
-                while (baseStructure.GetBoolExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-interface") == true)
+                while (baseStructure.GetBoolExtension(SnapshotGeneratorExtensions.STRUCTURE_DEFINITION_INTERFACE_EXT) == true)
                 {
                     var newBase = _resolver.FindStructureDefinition(baseStructure.BaseDefinition);
                     if (newBase == null)

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -274,7 +274,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             ElementDefinitionNavigator nav;
             // StructureDefinition.SnapshotComponent snapshot = null;
             if (structure.BaseDefinition != null)
-            {
+            {               
                 var baseStructure = _resolver.FindStructureDefinition(structure.BaseDefinition);
 
                 // [WMR 20161208] Handle unresolved base profile
@@ -283,6 +283,19 @@ namespace Hl7.Fhir.Specification.Snapshot
                     addIssueProfileNotFound(structure.BaseDefinition);
                     // Fatal error...
                     return null;
+                }
+
+                // [MMS 20200203] Skip interface structures while looking for base profile
+                while (baseStructure.GetBoolExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-interface") == true)
+                {
+                    var newBase = _resolver.FindStructureDefinition(baseStructure.BaseDefinition);
+                    if (newBase == null)
+                    {
+                        addIssueProfileNotFound(baseStructure.BaseDefinition);
+                        // Fatal error...
+                        return null;
+                    }
+                    baseStructure = newBase;
                 }
 
                 // [WMR 20161208] Handle missing differential
@@ -714,6 +727,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // [WMR 20190723] FIX: Initialize base cardinality from current diff element
                 // Do NOT inherit from target, e.g. Resource.id (0...1) inherits from id root (0...*)
                 // [DEBUGGING] Debug.Assert(newElement.Path != "Resource.id");
+
                 newElement.Base = new ElementDefinition.BaseComponent()
                 {
                     Path = newElement.Path,

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -25,6 +25,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <summary>The canonical url of the extension definition that marks snapshot elements with associated differential constraints.</summary>
         // public static readonly string CHANGED_BY_DIFF_EXT = "http://hl7.org/fhir/StructureDefinition/changedByDifferential";
         public static readonly string CONSTRAINED_BY_DIFF_EXT = "http://hl7.org/fhir/StructureDefinition/constrainedByDifferentialExtension";
+        public static readonly string STRUCTURE_DEFINITION_INTERFACE_EXT = "http://hl7.org/fhir/StructureDefinition/structuredefinition-interface";
 
         /// <summary>
         /// Decorate the specified snapshot element definition with a special extension


### PR DESCRIPTION
checks if baseDefinition is annotated with the "interface" extension.  If so, skip and resolve the next baseDefinition.