### PR TITLE
#984 - Added tests for additional exceptional elements (for R3)

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
@@ -137,7 +137,8 @@ namespace Hl7.Fhir.Specification
                     .Select(c => FromCanonical(c));
             }
 
-            throw new StructureDefinitionWalkerException($"Invalid StructureDefinition: element misses either a type reference or nameReference at '{Current.CanonicalPath()}'");
+            throw new StructureDefinitionWalkerException("Invalid StructureDefinition: element misses either a type reference or " +
+                $"a value in ElementDefinition.contentReference at '{Current.CanonicalPath()}'");
         }
 
         /// <summary>


### PR DESCRIPTION
I developed a comprehensive set of tests to check behaviour of the different `IStructureDefinitionSummaryProviders` for the various exceptional elements (like Element.id, Narrative.div etc).

This test is now present and exactly the same in R3+R4+R5.
