### PR TITLE
#984 - Added tests for additional exceptional elements (for R5)

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SerializationInfoTestsHelpers.cs
@@ -114,9 +114,17 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.AreEqual(types.Count() > 1, child.IsChoiceElement);
             Assert.AreEqual(mayRepeat, child.IsCollection);
             Assert.IsTrue(child.Type.All(t => t is IStructureDefinitionReference));
+
+            if (types.Length == 1 && child.Type.Length == 1)
+            {
+                Assert.AreEqual(types.Single(), ((IStructureDefinitionReference)child.Type.Single()).ReferredType);
+            }
+            else
+            {
             CollectionAssert.AreEqual(types, child.Type
                 .Cast<IStructureDefinitionReference>()
                 .Select(t => t.ReferredType).ToArray());
+        }
         }
 
         private static IStructureDefinitionSummary checkBBType(IStructureDefinitionSummary parent, string ename, string bbType, bool mayRepeat)
@@ -135,18 +143,33 @@ namespace Hl7.Fhir.Serialization.Tests
 
         public static void TestSpecialTypes(IStructureDefinitionSummaryProvider provider)
         {
-            // Narrative.div
-            var div = provider.Provide("Narrative");
-            Assert.IsNotNull(div);
-            checkType(div, "div", false, "xhtml");
+            //string FP_STRING = "http://hl7.org/fhirpath/System.String";
+            //string FP_DATETIME = "http://hl7.org/fhirpath/System.DateTime";
 
             // Element.id
-            checkType(div, "id", false, "string");
+            var elem = provider.Provide("Element");
+            checkType(elem, "id", false, "string");
 
-            var ext = provider.Provide("Extension");
+            // xhtml.id
+            var xhtml = provider.Provide("xhtml");
+            checkType(xhtml, "id", false, "string");
+
+            // Narrative.div
+            var div = provider.Provide("Narrative");
+            checkType(div, "div", false, "xhtml");
+            checkType(div, "id", false, "string");  // also try `id` in a derived element
 
             // Extension.url
+            var ext = provider.Provide("Extension");
             checkType(ext, "url", false, "uri");
+
+            // Resource.id
+            var res = provider.Provide("Resource");
+            checkType(res, "id", false, "id");
+
+            // Patient.id - derived type
+            res = provider.Provide("Patient");
+            checkType(res, "id", false, "id");
         }
 
         public static void TestProvidedOrder(IStructureDefinitionSummaryProvider provider)

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
@@ -137,7 +137,8 @@ namespace Hl7.Fhir.Specification
                     .Select(c => FromCanonical(c));
             }
 
-            throw new StructureDefinitionWalkerException($"Invalid StructureDefinition: element misses either a type reference or nameReference at '{Current.CanonicalPath()}'");
+            throw new StructureDefinitionWalkerException("Invalid StructureDefinition: element misses either a type reference or " +
+                $"a value in ElementDefinition.contentReference at '{Current.CanonicalPath()}'");
         }
 
         /// <summary>

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -192,13 +192,16 @@ namespace Hl7.Fhir.Specification
 
                 return new[] { (ITypeSerializationInfo)new BackboneElementComplexTypeSerializationInfo(reference) };
             }
-            else if (nav.Current.Path == "Extension.url")        // Compiler magic since R4
-            {
-                return new[] { (ITypeSerializationInfo)new TypeReferenceInfo("uri") };
-            }
             else
             {
-                if (nav.Current.Type[0].GetExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")?.Value is FhirUri uri)
+                var basePath = nav.Current?.Base?.Path;
+               
+                if (basePath == "xhtml.id" || nav.Current?.Path == "xhtml.id")
+                {
+                    // [EK 20200423] xhtml.id is missing the structuredefinition-fhir-type extension
+                    return new[] { (ITypeSerializationInfo)new TypeReferenceInfo("string") };
+                }
+                else if (nav.Current.Type[0].GetExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type")?.Value is FhirUri uri)
                 {
                     return new[] { (ITypeSerializationInfo)new TypeReferenceInfo(uri?.Value) };
                 }


### PR DESCRIPTION
I developed a comprehensive set of tests to check behaviour of the different `IStructureDefinitionSummaryProviders` for the various exceptional elements (like Element.id, Narrative.div etc).

This test is now present and exactly the same in R3+R4+R5.