### PR TITLE
#1325 - Removed root element extension inheritance in profiles

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -379,6 +379,9 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(expanded);
             dumpBaseElems(expanded);
 
+            var identifierValueElement = expanded.Single(element => element.Path == "Organization.identifier.value");
+            identifierValueElement.Extension.Should().BeEmpty("Extensions on the value type should not be inherited");
+
             Assert.IsNull(_generator.Outcome);
         }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -2173,6 +2173,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Structure has no base, i.e. core type definition => differential introduces & defines the root element
                 // No need to rebase, nothing to merge
                 var snapRoot = (ElementDefinition)diffRoot.DeepCopy();
+                snapRoot.Extension.Clear();
 
 #if CACHE_ROOT_ELEMDEF
                 Debug.Assert(!snapRoot.HasSnapshotElementAnnotation());


### PR DESCRIPTION
In this PR the inheritance of a StructureDefinition's root element extensions is removed. This fix has to be ported to R5 and STU3 as well, although in the latter the inheritance does not lead to problems
