### PR TITLE
Parser: ignores xml namespace check on contained resources when permissive parsing is turned on

### DIFF
--- a/src/Hl7.Fhir.Serialization.Tests/Hl7.Fhir.Serialization.Tests.csproj
+++ b/src/Hl7.Fhir.Serialization.Tests/Hl7.Fhir.Serialization.Tests.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <None Remove="TestData\BundleWithOneEntry.json" />
     <None Remove="TestData\mask-text.xml" />
+    <None Remove="TestData\no-namespace.xml" />
     <None Remove="TestData\patient-out-of-order.xml" />
     <None Remove="TestData\profiles-types.json" />
     <None Remove="TestData\profiles-types.xml" />

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -125,6 +125,15 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
+        public void CatchesMissingNamespace()
+        {
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "no-namespace.xml"));
+            var bundle = FhirXmlNode.Parse(tpXml, new FhirXmlParsingSettings { PermissiveParsing = true });
+            var result = bundle.ToTypedElement(new PocoStructureDefinitionSummaryProvider()).VisitAndCatch();
+            Assert.AreEqual(1000, result.Count);
+        }
+
+        [TestMethod]
         public void CatchesBasicTypeErrors()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "typeErrors.xml"));

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -130,7 +130,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var tpXml = File.ReadAllText(Path.Combine("TestData", "no-namespace.xml"));
             var bundle = FhirXmlNode.Parse(tpXml, new FhirXmlParsingSettings { PermissiveParsing = true });
             var result = bundle.ToTypedElement(new PocoStructureDefinitionSummaryProvider()).VisitAndCatch();
-            Assert.AreEqual(1000, result.Count);
+            Assert.AreEqual(0, result.Count);
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Serialization.Tests/TestData/no-namespace.xml
+++ b/src/Hl7.Fhir.Serialization.Tests/TestData/no-namespace.xml
@@ -1,0 +1,35 @@
+﻿<Bundle>
+  <id value="bundle-example"/>
+  <meta>
+    <lastUpdated value="2014-08-18T01:43:30Z"/>
+  </meta>
+  <type value="searchset"/>
+  <total value="3"/>
+  <entry>
+    <fullUrl value="https://example.com/base/MedicationRequest/3123"/>
+    <resource>
+      <MedicationRequest>
+        <id value="3123"/>
+        <!--    snip    -->
+        <text>
+          <status value="generated"/>
+          <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>snip</p>
+          </div>
+        </text>
+        <status value="unknown"/>
+        <intent value="order"/>
+        <medicationReference>
+          <reference value="Medication/example"/>
+        </medicationReference>
+        <subject>
+          <reference value="Patient/347"/>
+        </subject>
+      </MedicationRequest>
+    </resource>
+    <search>
+      <mode value="match"/>
+      <score value="1"/>
+    </search>
+  </entry>
+</Bundle>


### PR DESCRIPTION
fixes #1220