### PR TITLE
Name the backbones according to the `explicit-type-name` extension (for R3)

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Generated/Account.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Account.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Account#Account.coverage", IsNestedType=true)]
+        [FhirType("Account#Coverage", IsNestedType=true)]
         [DataContract]
         public partial class CoverageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CoverageComponent"; } }
+            public override string TypeName { get { return "Account#Coverage"; } }
             
             /// <summary>
             /// The party(s) that are responsible for covering the payment of this account
@@ -201,11 +201,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Account#Account.guarantor", IsNestedType=true)]
+        [FhirType("Account#Guarantor", IsNestedType=true)]
         [DataContract]
         public partial class GuarantorComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GuarantorComponent"; } }
+            public override string TypeName { get { return "Account#Guarantor"; } }
             
             /// <summary>
             /// Responsible entity

--- a/src/Hl7.Fhir.Core/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ActivityDefinition.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ActivityDefinition"; } }
         
-        [FhirType("ActivityDefinition#ActivityDefinition.participant", IsNestedType=true)]
+        [FhirType("ActivityDefinition#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "ActivityDefinition#Participant"; } }
             
             /// <summary>
             /// patient | practitioner | related-person
@@ -172,11 +172,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ActivityDefinition#ActivityDefinition.dynamicValue", IsNestedType=true)]
+        [FhirType("ActivityDefinition#DynamicValue", IsNestedType=true)]
         [DataContract]
         public partial class DynamicValueComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DynamicValueComponent"; } }
+            public override string TypeName { get { return "ActivityDefinition#DynamicValue"; } }
             
             /// <summary>
             /// Natural language description of the dynamic value

--- a/src/Hl7.Fhir.Core/Model/Generated/AdverseEvent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AdverseEvent.cs
@@ -94,11 +94,11 @@ namespace Hl7.Fhir.Model
             Causality2,
         }
 
-        [FhirType("AdverseEvent#AdverseEvent.suspectEntity", IsNestedType=true)]
+        [FhirType("AdverseEvent#SuspectEntity", IsNestedType=true)]
         [DataContract]
         public partial class SuspectEntityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SuspectEntityComponent"; } }
+            public override string TypeName { get { return "AdverseEvent#SuspectEntity"; } }
             
             /// <summary>
             /// Refers to the specific entity that caused the adverse event

--- a/src/Hl7.Fhir.Core/Model/Generated/AllergyIntolerance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AllergyIntolerance.cs
@@ -220,11 +220,11 @@ namespace Hl7.Fhir.Model
             Severe,
         }
 
-        [FhirType("AllergyIntolerance#AllergyIntolerance.reaction", IsNestedType=true)]
+        [FhirType("AllergyIntolerance#Reaction", IsNestedType=true)]
         [DataContract]
         public partial class ReactionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ReactionComponent"; } }
+            public override string TypeName { get { return "AllergyIntolerance#Reaction"; } }
             
             /// <summary>
             /// Specific substance or pharmaceutical product considered to be responsible for event

--- a/src/Hl7.Fhir.Core/Model/Generated/Appointment.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Appointment.cs
@@ -136,11 +136,11 @@ namespace Hl7.Fhir.Model
             InformationOnly,
         }
 
-        [FhirType("Appointment#Appointment.participant", IsNestedType=true)]
+        [FhirType("Appointment#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "Appointment#Participant"; } }
             
             /// <summary>
             /// Role of participant in the appointment

--- a/src/Hl7.Fhir.Core/Model/Generated/AuditEvent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AuditEvent.cs
@@ -163,11 +163,11 @@ namespace Hl7.Fhir.Model
             N5,
         }
 
-        [FhirType("AuditEvent#AuditEvent.agent", IsNestedType=true)]
+        [FhirType("AuditEvent#Agent", IsNestedType=true)]
         [DataContract]
         public partial class AgentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AgentComponent"; } }
+            public override string TypeName { get { return "AuditEvent#Agent"; } }
             
             /// <summary>
             /// Agent role in the event
@@ -506,11 +506,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("AuditEvent#AuditEvent.agent.network", IsNestedType=true)]
+        [FhirType("AuditEvent#Network", IsNestedType=true)]
         [DataContract]
         public partial class NetworkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NetworkComponent"; } }
+            public override string TypeName { get { return "AuditEvent#Network"; } }
             
             /// <summary>
             /// Identifier for the network access point of the user device
@@ -643,11 +643,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("AuditEvent#AuditEvent.source", IsNestedType=true)]
+        [FhirType("AuditEvent#Source", IsNestedType=true)]
         [DataContract]
         public partial class SourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SourceComponent"; } }
+            public override string TypeName { get { return "AuditEvent#Source"; } }
             
             /// <summary>
             /// Logical source location within the enterprise
@@ -782,11 +782,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("AuditEvent#AuditEvent.entity", IsNestedType=true)]
+        [FhirType("AuditEvent#Entity", IsNestedType=true)]
         [DataContract]
         public partial class EntityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EntityComponent"; } }
+            public override string TypeName { get { return "AuditEvent#Entity"; } }
             
             /// <summary>
             /// Specific instance of object
@@ -1085,11 +1085,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("AuditEvent#AuditEvent.entity.detail", IsNestedType=true)]
+        [FhirType("AuditEvent#Detail", IsNestedType=true)]
         [DataContract]
         public partial class DetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DetailComponent"; } }
+            public override string TypeName { get { return "AuditEvent#Detail"; } }
             
             /// <summary>
             /// Name of the property

--- a/src/Hl7.Fhir.Core/Model/Generated/Bundle.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Bundle.cs
@@ -175,11 +175,11 @@ namespace Hl7.Fhir.Model
             DELETE,
         }
 
-        [FhirType("Bundle#Bundle.link", IsNestedType=true)]
+        [FhirType("Bundle#Link", IsNestedType=true)]
         [DataContract]
         public partial class LinkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LinkComponent"; } }
+            public override string TypeName { get { return "Bundle#Link"; } }
             
             /// <summary>
             /// See http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1
@@ -314,11 +314,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Bundle#Bundle.entry", IsNestedType=true)]
+        [FhirType("Bundle#Entry", IsNestedType=true)]
         [DataContract]
         public partial class EntryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EntryComponent"; } }
+            public override string TypeName { get { return "Bundle#Entry"; } }
             
             /// <summary>
             /// Links related to this entry
@@ -508,11 +508,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Bundle#Bundle.entry.search", IsNestedType=true)]
+        [FhirType("Bundle#Search", IsNestedType=true)]
         [DataContract]
         public partial class SearchComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SearchComponent"; } }
+            public override string TypeName { get { return "Bundle#Search"; } }
             
             /// <summary>
             /// match | include | outcome - why this is in the result set
@@ -645,11 +645,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Bundle#Bundle.entry.request", IsNestedType=true)]
+        [FhirType("Bundle#Request", IsNestedType=true)]
         [DataContract]
         public partial class RequestComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequestComponent"; } }
+            public override string TypeName { get { return "Bundle#Request"; } }
             
             /// <summary>
             /// GET | POST | PUT | DELETE
@@ -928,11 +928,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Bundle#Bundle.entry.response", IsNestedType=true)]
+        [FhirType("Bundle#Response", IsNestedType=true)]
         [DataContract]
         public partial class ResponseComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResponseComponent"; } }
+            public override string TypeName { get { return "Bundle#Response"; } }
             
             /// <summary>
             /// Status response code (text optional)

--- a/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement.cs
@@ -397,11 +397,11 @@ namespace Hl7.Fhir.Model
             Consumer,
         }
 
-        [FhirType("CapabilityStatement#CapabilityStatement.software", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Software", IsNestedType=true)]
         [DataContract]
         public partial class SoftwareComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SoftwareComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Software"; } }
             
             /// <summary>
             /// A name the software is known by
@@ -571,11 +571,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.implementation", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Implementation", IsNestedType=true)]
         [DataContract]
         public partial class ImplementationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ImplementationComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Implementation"; } }
             
             /// <summary>
             /// Describes this specific instance
@@ -709,11 +709,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Rest", IsNestedType=true)]
         [DataContract]
         public partial class RestComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RestComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Rest"; } }
             
             /// <summary>
             /// client | server
@@ -978,11 +978,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.security", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Security", IsNestedType=true)]
         [DataContract]
         public partial class SecurityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SecurityComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Security"; } }
             
             /// <summary>
             /// Adds CORS Headers (http://enable-cors.org/)
@@ -1153,11 +1153,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.security.certificate", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Certificate", IsNestedType=true)]
         [DataContract]
         public partial class CertificateComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CertificateComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Certificate"; } }
             
             /// <summary>
             /// Mime type for certificates
@@ -1290,11 +1290,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.resource", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Resource", IsNestedType=true)]
         [DataContract]
         public partial class ResourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResourceComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Resource"; } }
             
             /// <summary>
             /// A resource type that is supported
@@ -1831,11 +1831,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.resource.interaction", IsNestedType=true)]
+        [FhirType("CapabilityStatement#ResourceInteraction", IsNestedType=true)]
         [DataContract]
         public partial class ResourceInteractionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResourceInteractionComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#ResourceInteraction"; } }
             
             /// <summary>
             /// read | vread | update | patch | delete | history-instance | history-type | create | search-type
@@ -1969,11 +1969,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.resource.searchParam", IsNestedType=true)]
+        [FhirType("CapabilityStatement#SearchParam", IsNestedType=true)]
         [DataContract]
         public partial class SearchParamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SearchParamComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#SearchParam"; } }
             
             /// <summary>
             /// Name of search parameter
@@ -2180,11 +2180,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.interaction", IsNestedType=true)]
+        [FhirType("CapabilityStatement#SystemInteraction", IsNestedType=true)]
         [DataContract]
         public partial class SystemInteractionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SystemInteractionComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#SystemInteraction"; } }
             
             /// <summary>
             /// transaction | batch | search-system | history-system
@@ -2318,11 +2318,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.rest.operation", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Operation", IsNestedType=true)]
         [DataContract]
         public partial class OperationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OperationComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Operation"; } }
             
             /// <summary>
             /// Name by which the operation/query is invoked
@@ -2441,11 +2441,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.messaging", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Messaging", IsNestedType=true)]
         [DataContract]
         public partial class MessagingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MessagingComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Messaging"; } }
             
             /// <summary>
             /// Where messages should be sent
@@ -2635,11 +2635,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.messaging.endpoint", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Endpoint", IsNestedType=true)]
         [DataContract]
         public partial class EndpointComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EndpointComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Endpoint"; } }
             
             /// <summary>
             /// http | ftp | mllp +
@@ -2756,11 +2756,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.messaging.supportedMessage", IsNestedType=true)]
+        [FhirType("CapabilityStatement#SupportedMessage", IsNestedType=true)]
         [DataContract]
         public partial class SupportedMessageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SupportedMessageComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#SupportedMessage"; } }
             
             /// <summary>
             /// sender | receiver
@@ -2879,11 +2879,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.messaging.event", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Event", IsNestedType=true)]
         [DataContract]
         public partial class EventComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EventComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Event"; } }
             
             /// <summary>
             /// Event type
@@ -3151,11 +3151,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CapabilityStatement#CapabilityStatement.document", IsNestedType=true)]
+        [FhirType("CapabilityStatement#Document", IsNestedType=true)]
         [DataContract]
         public partial class DocumentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DocumentComponent"; } }
+            public override string TypeName { get { return "CapabilityStatement#Document"; } }
             
             /// <summary>
             /// producer | consumer

--- a/src/Hl7.Fhir.Core/Model/Generated/CarePlan.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CarePlan.cs
@@ -187,11 +187,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("CarePlan#CarePlan.activity", IsNestedType=true)]
+        [FhirType("CarePlan#Activity", IsNestedType=true)]
         [DataContract]
         public partial class ActivityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActivityComponent"; } }
+            public override string TypeName { get { return "CarePlan#Activity"; } }
             
             /// <summary>
             /// Results of the activity
@@ -349,11 +349,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CarePlan#CarePlan.activity.detail", IsNestedType=true)]
+        [FhirType("CarePlan#Detail", IsNestedType=true)]
         [DataContract]
         public partial class DetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DetailComponent"; } }
+            public override string TypeName { get { return "CarePlan#Detail"; } }
             
             /// <summary>
             /// diet | drug | encounter | observation | procedure | supply | other

--- a/src/Hl7.Fhir.Core/Model/Generated/CareTeam.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CareTeam.cs
@@ -91,11 +91,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("CareTeam#CareTeam.participant", IsNestedType=true)]
+        [FhirType("CareTeam#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "CareTeam#Participant"; } }
             
             /// <summary>
             /// Type of involvement

--- a/src/Hl7.Fhir.Core/Model/Generated/ChargeItem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ChargeItem.cs
@@ -103,11 +103,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("ChargeItem#ChargeItem.participant", IsNestedType=true)]
+        [FhirType("ChargeItem#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "ChargeItem#Participant"; } }
             
             /// <summary>
             /// What type of performance was done

--- a/src/Hl7.Fhir.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Claim.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             Other,
         }
 
-        [FhirType("Claim#Claim.related", IsNestedType=true)]
+        [FhirType("Claim#RelatedClaim", IsNestedType=true)]
         [DataContract]
         public partial class RelatedClaimComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedClaimComponent"; } }
+            public override string TypeName { get { return "Claim#RelatedClaim"; } }
             
             /// <summary>
             /// Reference to the related claim
@@ -206,11 +206,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.payee", IsNestedType=true)]
+        [FhirType("Claim#Payee", IsNestedType=true)]
         [DataContract]
         public partial class PayeeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PayeeComponent"; } }
+            public override string TypeName { get { return "Claim#Payee"; } }
             
             /// <summary>
             /// Type of party: Subscriber, Provider, other
@@ -328,11 +328,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.careTeam", IsNestedType=true)]
+        [FhirType("Claim#CareTeam", IsNestedType=true)]
         [DataContract]
         public partial class CareTeamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CareTeamComponent"; } }
+            public override string TypeName { get { return "Claim#CareTeam"; } }
             
             /// <summary>
             /// Number to covey order of careTeam
@@ -523,11 +523,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.information", IsNestedType=true)]
+        [FhirType("Claim#SpecialCondition", IsNestedType=true)]
         [DataContract]
         public partial class SpecialConditionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SpecialConditionComponent"; } }
+            public override string TypeName { get { return "Claim#SpecialCondition"; } }
             
             /// <summary>
             /// Information instance identifier
@@ -720,11 +720,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.diagnosis", IsNestedType=true)]
+        [FhirType("Claim#Diagnosis", IsNestedType=true)]
         [DataContract]
         public partial class DiagnosisComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DiagnosisComponent"; } }
+            public override string TypeName { get { return "Claim#Diagnosis"; } }
             
             /// <summary>
             /// Number to covey order of diagnosis
@@ -880,11 +880,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.procedure", IsNestedType=true)]
+        [FhirType("Claim#Procedure", IsNestedType=true)]
         [DataContract]
         public partial class ProcedureComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProcedureComponent"; } }
+            public override string TypeName { get { return "Claim#Procedure"; } }
             
             /// <summary>
             /// Procedure sequence for reference
@@ -1039,11 +1039,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.insurance", IsNestedType=true)]
+        [FhirType("Claim#Insurance", IsNestedType=true)]
         [DataContract]
         public partial class InsuranceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InsuranceComponent"; } }
+            public override string TypeName { get { return "Claim#Insurance"; } }
             
             /// <summary>
             /// Service instance identifier
@@ -1292,11 +1292,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.accident", IsNestedType=true)]
+        [FhirType("Claim#Accident", IsNestedType=true)]
         [DataContract]
         public partial class AccidentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AccidentComponent"; } }
+            public override string TypeName { get { return "Claim#Accident"; } }
             
             /// <summary>
             /// When the accident occurred
@@ -1436,11 +1436,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.item", IsNestedType=true)]
+        [FhirType("Claim#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "Claim#Item"; } }
             
             /// <summary>
             /// Service instance
@@ -2006,11 +2006,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.item.detail", IsNestedType=true)]
+        [FhirType("Claim#Detail", IsNestedType=true)]
         [DataContract]
         public partial class DetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DetailComponent"; } }
+            public override string TypeName { get { return "Claim#Detail"; } }
             
             /// <summary>
             /// Service instance
@@ -2330,11 +2330,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Claim#Claim.item.detail.subDetail", IsNestedType=true)]
+        [FhirType("Claim#SubDetail", IsNestedType=true)]
         [DataContract]
         public partial class SubDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SubDetailComponent"; } }
+            public override string TypeName { get { return "Claim#SubDetail"; } }
             
             /// <summary>
             /// Service instance

--- a/src/Hl7.Fhir.Core/Model/Generated/ClaimResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ClaimResponse.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ClaimResponse"; } }
         
-        [FhirType("ClaimResponse#ClaimResponse.item", IsNestedType=true)]
+        [FhirType("ClaimResponse#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Item"; } }
             
             /// <summary>
             /// Service instance
@@ -229,11 +229,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.item.adjudication", IsNestedType=true)]
+        [FhirType("ClaimResponse#Adjudication", IsNestedType=true)]
         [DataContract]
         public partial class AdjudicationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AdjudicationComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Adjudication"; } }
             
             /// <summary>
             /// Adjudication category such as co-pay, eligible, benefit, etc.
@@ -385,11 +385,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.item.detail", IsNestedType=true)]
+        [FhirType("ClaimResponse#ItemDetail", IsNestedType=true)]
         [DataContract]
         public partial class ItemDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemDetailComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#ItemDetail"; } }
             
             /// <summary>
             /// Service instance
@@ -562,11 +562,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.item.detail.subDetail", IsNestedType=true)]
+        [FhirType("ClaimResponse#SubDetail", IsNestedType=true)]
         [DataContract]
         public partial class SubDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SubDetailComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#SubDetail"; } }
             
             /// <summary>
             /// Service instance
@@ -720,11 +720,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.addItem", IsNestedType=true)]
+        [FhirType("ClaimResponse#AddedItem", IsNestedType=true)]
         [DataContract]
         public partial class AddedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AddedItemComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#AddedItem"; } }
             
             /// <summary>
             /// Service instances
@@ -988,11 +988,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.addItem.detail", IsNestedType=true)]
+        [FhirType("ClaimResponse#AddedItemsDetail", IsNestedType=true)]
         [DataContract]
         public partial class AddedItemsDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AddedItemsDetailComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#AddedItemsDetail"; } }
             
             /// <summary>
             /// Revenue or cost center code
@@ -1200,11 +1200,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.error", IsNestedType=true)]
+        [FhirType("ClaimResponse#Error", IsNestedType=true)]
         [DataContract]
         public partial class ErrorComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ErrorComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Error"; } }
             
             /// <summary>
             /// Item sequence number
@@ -1392,11 +1392,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.payment", IsNestedType=true)]
+        [FhirType("ClaimResponse#Payment", IsNestedType=true)]
         [DataContract]
         public partial class PaymentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PaymentComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Payment"; } }
             
             /// <summary>
             /// Partial or Complete
@@ -1583,11 +1583,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.processNote", IsNestedType=true)]
+        [FhirType("ClaimResponse#Note", IsNestedType=true)]
         [DataContract]
         public partial class NoteComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NoteComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Note"; } }
             
             /// <summary>
             /// Sequence Number for this note
@@ -1756,11 +1756,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClaimResponse#ClaimResponse.insurance", IsNestedType=true)]
+        [FhirType("ClaimResponse#Insurance", IsNestedType=true)]
         [DataContract]
         public partial class InsuranceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InsuranceComponent"; } }
+            public override string TypeName { get { return "ClaimResponse#Insurance"; } }
             
             /// <summary>
             /// Service instance identifier

--- a/src/Hl7.Fhir.Core/Model/Generated/ClinicalImpression.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ClinicalImpression.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("ClinicalImpression#ClinicalImpression.investigation", IsNestedType=true)]
+        [FhirType("ClinicalImpression#Investigation", IsNestedType=true)]
         [DataContract]
         public partial class InvestigationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InvestigationComponent"; } }
+            public override string TypeName { get { return "ClinicalImpression#Investigation"; } }
             
             /// <summary>
             /// A name/code for the set
@@ -184,11 +184,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ClinicalImpression#ClinicalImpression.finding", IsNestedType=true)]
+        [FhirType("ClinicalImpression#Finding", IsNestedType=true)]
         [DataContract]
         public partial class FindingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FindingComponent"; } }
+            public override string TypeName { get { return "ClinicalImpression#Finding"; } }
             
             /// <summary>
             /// What was found

--- a/src/Hl7.Fhir.Core/Model/Generated/CodeSystem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CodeSystem.cs
@@ -163,11 +163,11 @@ namespace Hl7.Fhir.Model
             DateTime,
         }
 
-        [FhirType("CodeSystem#CodeSystem.filter", IsNestedType=true)]
+        [FhirType("CodeSystem#Filter", IsNestedType=true)]
         [DataContract]
         public partial class FilterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FilterComponent"; } }
+            public override string TypeName { get { return "CodeSystem#Filter"; } }
             
             /// <summary>
             /// Code that identifies the filter
@@ -375,11 +375,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CodeSystem#CodeSystem.property", IsNestedType=true)]
+        [FhirType("CodeSystem#Property", IsNestedType=true)]
         [DataContract]
         public partial class PropertyComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PropertyComponent"; } }
+            public override string TypeName { get { return "CodeSystem#Property"; } }
             
             /// <summary>
             /// Identifies the property on the concepts, and when referred to in operations
@@ -586,11 +586,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CodeSystem#CodeSystem.concept", IsNestedType=true)]
+        [FhirType("CodeSystem#ConceptDefinition", IsNestedType=true)]
         [DataContract]
         public partial class ConceptDefinitionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConceptDefinitionComponent"; } }
+            public override string TypeName { get { return "CodeSystem#ConceptDefinition"; } }
             
             /// <summary>
             /// Code that identifies concept
@@ -817,11 +817,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CodeSystem#CodeSystem.concept.designation", IsNestedType=true)]
+        [FhirType("CodeSystem#Designation", IsNestedType=true)]
         [DataContract]
         public partial class DesignationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationComponent"; } }
+            public override string TypeName { get { return "CodeSystem#Designation"; } }
             
             /// <summary>
             /// Human language of the designation
@@ -973,11 +973,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CodeSystem#CodeSystem.concept.property", IsNestedType=true)]
+        [FhirType("CodeSystem#ConceptProperty", IsNestedType=true)]
         [DataContract]
         public partial class ConceptPropertyComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConceptPropertyComponent"; } }
+            public override string TypeName { get { return "CodeSystem#ConceptProperty"; } }
             
             /// <summary>
             /// Reference to CodeSystem.property.code

--- a/src/Hl7.Fhir.Core/Model/Generated/Communication.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Communication.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Communication"; } }
         
-        [FhirType("Communication#Communication.payload", IsNestedType=true)]
+        [FhirType("Communication#Payload", IsNestedType=true)]
         [DataContract]
         public partial class PayloadComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PayloadComponent"; } }
+            public override string TypeName { get { return "Communication#Payload"; } }
             
             /// <summary>
             /// Message part content

--- a/src/Hl7.Fhir.Core/Model/Generated/CommunicationRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CommunicationRequest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "CommunicationRequest"; } }
         
-        [FhirType("CommunicationRequest#CommunicationRequest.payload", IsNestedType=true)]
+        [FhirType("CommunicationRequest#Payload", IsNestedType=true)]
         [DataContract]
         public partial class PayloadComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PayloadComponent"; } }
+            public override string TypeName { get { return "CommunicationRequest#Payload"; } }
             
             /// <summary>
             /// Message part content
@@ -138,11 +138,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("CommunicationRequest#CommunicationRequest.requester", IsNestedType=true)]
+        [FhirType("CommunicationRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "CommunicationRequest#Requester"; } }
             
             /// <summary>
             /// Individual making the request

--- a/src/Hl7.Fhir.Core/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CompartmentDefinition.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "CompartmentDefinition"; } }
         
-        [FhirType("CompartmentDefinition#CompartmentDefinition.resource", IsNestedType=true)]
+        [FhirType("CompartmentDefinition#Resource", IsNestedType=true)]
         [DataContract]
         public partial class ResourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResourceComponent"; } }
+            public override string TypeName { get { return "CompartmentDefinition#Resource"; } }
             
             /// <summary>
             /// Name of resource type

--- a/src/Hl7.Fhir.Core/Model/Generated/Composition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Composition.cs
@@ -130,11 +130,11 @@ namespace Hl7.Fhir.Model
             Official,
         }
 
-        [FhirType("Composition#Composition.attester", IsNestedType=true)]
+        [FhirType("Composition#Attester", IsNestedType=true)]
         [DataContract]
         public partial class AttesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AttesterComponent"; } }
+            public override string TypeName { get { return "Composition#Attester"; } }
             
             /// <summary>
             /// personal | professional | legal | official
@@ -288,11 +288,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Composition#Composition.relatesTo", IsNestedType=true)]
+        [FhirType("Composition#RelatesTo", IsNestedType=true)]
         [DataContract]
         public partial class RelatesToComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatesToComponent"; } }
+            public override string TypeName { get { return "Composition#RelatesTo"; } }
             
             /// <summary>
             /// replaces | transforms | signs | appends
@@ -411,11 +411,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Composition#Composition.event", IsNestedType=true)]
+        [FhirType("Composition#Event", IsNestedType=true)]
         [DataContract]
         public partial class EventComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EventComponent"; } }
+            public override string TypeName { get { return "Composition#Event"; } }
             
             /// <summary>
             /// Code(s) that apply to the event being documented
@@ -534,11 +534,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Composition#Composition.section", IsNestedType=true)]
+        [FhirType("Composition#Section", IsNestedType=true)]
         [DataContract]
         public partial class SectionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SectionComponent"; } }
+            public override string TypeName { get { return "Composition#Section"; } }
             
             /// <summary>
             /// Label for section (e.g. for ToC)

--- a/src/Hl7.Fhir.Core/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ConceptMap.cs
@@ -148,11 +148,11 @@ namespace Hl7.Fhir.Model
             OtherMap,
         }
 
-        [FhirType("ConceptMap#ConceptMap.group", IsNestedType=true)]
+        [FhirType("ConceptMap#Group", IsNestedType=true)]
         [DataContract]
         public partial class GroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GroupComponent"; } }
+            public override string TypeName { get { return "ConceptMap#Group"; } }
             
             /// <summary>
             /// Code System (if value set crosses code systems)
@@ -394,11 +394,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ConceptMap#ConceptMap.group.element", IsNestedType=true)]
+        [FhirType("ConceptMap#SourceElement", IsNestedType=true)]
         [DataContract]
         public partial class SourceElementComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SourceElementComponent"; } }
+            public override string TypeName { get { return "ConceptMap#SourceElement"; } }
             
             /// <summary>
             /// Identifies element being mapped
@@ -550,11 +550,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ConceptMap#ConceptMap.group.element.target", IsNestedType=true)]
+        [FhirType("ConceptMap#TargetElement", IsNestedType=true)]
         [DataContract]
         public partial class TargetElementComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TargetElementComponent"; } }
+            public override string TypeName { get { return "ConceptMap#TargetElement"; } }
             
             /// <summary>
             /// Code that identifies the target element
@@ -797,11 +797,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ConceptMap#ConceptMap.group.element.target.dependsOn", IsNestedType=true)]
+        [FhirType("ConceptMap#OtherElement", IsNestedType=true)]
         [DataContract]
         public partial class OtherElementComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OtherElementComponent"; } }
+            public override string TypeName { get { return "ConceptMap#OtherElement"; } }
             
             /// <summary>
             /// Reference to property mapping depends on
@@ -1008,11 +1008,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ConceptMap#ConceptMap.group.unmapped", IsNestedType=true)]
+        [FhirType("ConceptMap#Unmapped", IsNestedType=true)]
         [DataContract]
         public partial class UnmappedComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "UnmappedComponent"; } }
+            public override string TypeName { get { return "ConceptMap#Unmapped"; } }
             
             /// <summary>
             /// provided | fixed | other-map

--- a/src/Hl7.Fhir.Core/Model/Generated/Condition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Condition.cs
@@ -136,11 +136,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("Condition#Condition.stage", IsNestedType=true)]
+        [FhirType("Condition#Stage", IsNestedType=true)]
         [DataContract]
         public partial class StageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StageComponent"; } }
+            public override string TypeName { get { return "Condition#Stage"; } }
             
             /// <summary>
             /// Simple summary (disease specific)
@@ -240,11 +240,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Condition#Condition.evidence", IsNestedType=true)]
+        [FhirType("Condition#Evidence", IsNestedType=true)]
         [DataContract]
         public partial class EvidenceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EvidenceComponent"; } }
+            public override string TypeName { get { return "Condition#Evidence"; } }
             
             /// <summary>
             /// Manifestation/symptom

--- a/src/Hl7.Fhir.Core/Model/Generated/Consent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Consent.cs
@@ -151,11 +151,11 @@ namespace Hl7.Fhir.Model
             Permit,
         }
 
-        [FhirType("Consent#Consent.actor", IsNestedType=true)]
+        [FhirType("Consent#Actor", IsNestedType=true)]
         [DataContract]
         public partial class ActorComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActorComponent"; } }
+            public override string TypeName { get { return "Consent#Actor"; } }
             
             /// <summary>
             /// How the actor is involved
@@ -256,11 +256,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Consent#Consent.policy", IsNestedType=true)]
+        [FhirType("Consent#Policy", IsNestedType=true)]
         [DataContract]
         public partial class PolicyComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PolicyComponent"; } }
+            public override string TypeName { get { return "Consent#Policy"; } }
             
             /// <summary>
             /// Enforcement source for policy
@@ -393,11 +393,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Consent#Consent.data", IsNestedType=true)]
+        [FhirType("Consent#Data", IsNestedType=true)]
         [DataContract]
         public partial class DataComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DataComponent"; } }
+            public override string TypeName { get { return "Consent#Data"; } }
             
             /// <summary>
             /// instance | related | dependents | authoredby
@@ -516,11 +516,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Consent#Consent.except", IsNestedType=true)]
+        [FhirType("Consent#Except", IsNestedType=true)]
         [DataContract]
         public partial class ExceptComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExceptComponent"; } }
+            public override string TypeName { get { return "Consent#Except"; } }
             
             /// <summary>
             /// deny | permit
@@ -787,11 +787,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Consent#Consent.except.actor", IsNestedType=true)]
+        [FhirType("Consent#ExceptActor", IsNestedType=true)]
         [DataContract]
         public partial class ExceptActorComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExceptActorComponent"; } }
+            public override string TypeName { get { return "Consent#ExceptActor"; } }
             
             /// <summary>
             /// How the actor is involved
@@ -892,11 +892,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Consent#Consent.except.data", IsNestedType=true)]
+        [FhirType("Consent#ExceptData", IsNestedType=true)]
         [DataContract]
         public partial class ExceptDataComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExceptDataComponent"; } }
+            public override string TypeName { get { return "Consent#ExceptData"; } }
             
             /// <summary>
             /// instance | related | dependents | authoredby

--- a/src/Hl7.Fhir.Core/Model/Generated/Contract.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Contract.cs
@@ -151,11 +151,11 @@ namespace Hl7.Fhir.Model
             Terminated,
         }
 
-        [FhirType("Contract#Contract.agent", IsNestedType=true)]
+        [FhirType("Contract#Agent", IsNestedType=true)]
         [DataContract]
         public partial class AgentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AgentComponent"; } }
+            public override string TypeName { get { return "Contract#Agent"; } }
             
             /// <summary>
             /// Contract Agent Type
@@ -256,11 +256,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.signer", IsNestedType=true)]
+        [FhirType("Contract#Signatory", IsNestedType=true)]
         [DataContract]
         public partial class SignatoryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SignatoryComponent"; } }
+            public override string TypeName { get { return "Contract#Signatory"; } }
             
             /// <summary>
             /// Contract Signatory Role
@@ -380,11 +380,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.valuedItem", IsNestedType=true)]
+        [FhirType("Contract#ValuedItem", IsNestedType=true)]
         [DataContract]
         public partial class ValuedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ValuedItemComponent"; } }
+            public override string TypeName { get { return "Contract#ValuedItem"; } }
             
             /// <summary>
             /// Contract Valued Item Type
@@ -645,11 +645,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.term", IsNestedType=true)]
+        [FhirType("Contract#Term", IsNestedType=true)]
         [DataContract]
         public partial class TermComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TermComponent"; } }
+            public override string TypeName { get { return "Contract#Term"; } }
             
             /// <summary>
             /// Contract Term Number
@@ -989,11 +989,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.term.agent", IsNestedType=true)]
+        [FhirType("Contract#TermAgent", IsNestedType=true)]
         [DataContract]
         public partial class TermAgentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TermAgentComponent"; } }
+            public override string TypeName { get { return "Contract#TermAgent"; } }
             
             /// <summary>
             /// Contract Term Agent Subject
@@ -1094,11 +1094,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.term.valuedItem", IsNestedType=true)]
+        [FhirType("Contract#TermValuedItem", IsNestedType=true)]
         [DataContract]
         public partial class TermValuedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TermValuedItemComponent"; } }
+            public override string TypeName { get { return "Contract#TermValuedItem"; } }
             
             /// <summary>
             /// Contract Term Valued Item Type
@@ -1359,11 +1359,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.friendly", IsNestedType=true)]
+        [FhirType("Contract#FriendlyLanguage", IsNestedType=true)]
         [DataContract]
         public partial class FriendlyLanguageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FriendlyLanguageComponent"; } }
+            public override string TypeName { get { return "Contract#FriendlyLanguage"; } }
             
             /// <summary>
             /// Easily comprehended representation of this Contract
@@ -1445,11 +1445,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.legal", IsNestedType=true)]
+        [FhirType("Contract#LegalLanguage", IsNestedType=true)]
         [DataContract]
         public partial class LegalLanguageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LegalLanguageComponent"; } }
+            public override string TypeName { get { return "Contract#LegalLanguage"; } }
             
             /// <summary>
             /// Contract Legal Text
@@ -1531,11 +1531,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Contract#Contract.rule", IsNestedType=true)]
+        [FhirType("Contract#ComputableLanguage", IsNestedType=true)]
         [DataContract]
         public partial class ComputableLanguageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ComputableLanguageComponent"; } }
+            public override string TypeName { get { return "Contract#ComputableLanguage"; } }
             
             /// <summary>
             /// Computable Contract Rules

--- a/src/Hl7.Fhir.Core/Model/Generated/Coverage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Coverage.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Coverage"; } }
         
-        [FhirType("Coverage#Coverage.grouping", IsNestedType=true)]
+        [FhirType("Coverage#Group", IsNestedType=true)]
         [DataContract]
         public partial class GroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GroupComponent"; } }
+            public override string TypeName { get { return "Coverage#Group"; } }
             
             /// <summary>
             /// An identifier for the group

--- a/src/Hl7.Fhir.Core/Model/Generated/DataElement.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DataElement.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             Flexible,
         }
 
-        [FhirType("DataElement#DataElement.mapping", IsNestedType=true)]
+        [FhirType("DataElement#Mapping", IsNestedType=true)]
         [DataContract]
         public partial class MappingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MappingComponent"; } }
+            public override string TypeName { get { return "DataElement#Mapping"; } }
             
             /// <summary>
             /// Internal id when this mapping is used

--- a/src/Hl7.Fhir.Core/Model/Generated/DataRequirement.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DataRequirement.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "DataRequirement"; } }
         
-        [FhirType("DataRequirement#DataRequirement.codeFilter", IsNestedType=true)]
+        [FhirType("DataRequirement#CodeFilter", IsNestedType=true)]
         [DataContract]
         public partial class CodeFilterComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "CodeFilterComponent"; } }
+            public override string TypeName { get { return "DataRequirement#CodeFilter"; } }
             
             /// <summary>
             /// The code-valued attribute of the filter
@@ -246,11 +246,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("DataRequirement#DataRequirement.dateFilter", IsNestedType=true)]
+        [FhirType("DataRequirement#DateFilter", IsNestedType=true)]
         [DataContract]
         public partial class DateFilterComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "DateFilterComponent"; } }
+            public override string TypeName { get { return "DataRequirement#DateFilter"; } }
             
             /// <summary>
             /// The date-valued attribute of the filter

--- a/src/Hl7.Fhir.Core/Model/Generated/DetectedIssue.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DetectedIssue.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             Low,
         }
 
-        [FhirType("DetectedIssue#DetectedIssue.mitigation", IsNestedType=true)]
+        [FhirType("DetectedIssue#Mitigation", IsNestedType=true)]
         [DataContract]
         public partial class MitigationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MitigationComponent"; } }
+            public override string TypeName { get { return "DetectedIssue#Mitigation"; } }
             
             /// <summary>
             /// What mitigation?

--- a/src/Hl7.Fhir.Core/Model/Generated/Device.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Device.cs
@@ -130,11 +130,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("Device#Device.udi", IsNestedType=true)]
+        [FhirType("Device#Udi", IsNestedType=true)]
         [DataContract]
         public partial class UdiComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "UdiComponent"; } }
+            public override string TypeName { get { return "Device#Udi"; } }
             
             /// <summary>
             /// Mandatory fixed portion of UDI

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceComponent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceComponent.cs
@@ -127,11 +127,11 @@ namespace Hl7.Fhir.Model
             Manual,
         }
 
-        [FhirType("DeviceComponent#DeviceComponent.productionSpecification", IsNestedType=true)]
+        [FhirType("DeviceComponent#ProductionSpecification", IsNestedType=true)]
         [DataContract]
         public partial class ProductionSpecificationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProductionSpecificationComponent"; } }
+            public override string TypeName { get { return "DeviceComponent#ProductionSpecification"; } }
             
             /// <summary>
             /// Type or kind of production specification, for example serial number or software revision

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceMetric.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceMetric.cs
@@ -241,11 +241,11 @@ namespace Hl7.Fhir.Model
             Unspecified,
         }
 
-        [FhirType("DeviceMetric#DeviceMetric.calibration", IsNestedType=true)]
+        [FhirType("DeviceMetric#Calibration", IsNestedType=true)]
         [DataContract]
         public partial class CalibrationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CalibrationComponent"; } }
+            public override string TypeName { get { return "DeviceMetric#Calibration"; } }
             
             /// <summary>
             /// unspecified | offset | gain | two-point

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceRequest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "DeviceRequest"; } }
         
-        [FhirType("DeviceRequest#DeviceRequest.requester", IsNestedType=true)]
+        [FhirType("DeviceRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "DeviceRequest#Requester"; } }
             
             /// <summary>
             /// Individual making the request

--- a/src/Hl7.Fhir.Core/Model/Generated/DiagnosticReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DiagnosticReport.cs
@@ -121,11 +121,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("DiagnosticReport#DiagnosticReport.performer", IsNestedType=true)]
+        [FhirType("DiagnosticReport#Performer", IsNestedType=true)]
         [DataContract]
         public partial class PerformerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PerformerComponent"; } }
+            public override string TypeName { get { return "DiagnosticReport#Performer"; } }
             
             /// <summary>
             /// Type of performer
@@ -225,11 +225,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("DiagnosticReport#DiagnosticReport.image", IsNestedType=true)]
+        [FhirType("DiagnosticReport#Image", IsNestedType=true)]
         [DataContract]
         public partial class ImageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ImageComponent"; } }
+            public override string TypeName { get { return "DiagnosticReport#Image"; } }
             
             /// <summary>
             /// Comment about the image (e.g. explanation)

--- a/src/Hl7.Fhir.Core/Model/Generated/DocumentManifest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DocumentManifest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "DocumentManifest"; } }
         
-        [FhirType("DocumentManifest#DocumentManifest.content", IsNestedType=true)]
+        [FhirType("DocumentManifest#Content", IsNestedType=true)]
         [DataContract]
         public partial class ContentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContentComponent"; } }
+            public override string TypeName { get { return "DocumentManifest#Content"; } }
             
             /// <summary>
             /// Contents of this set of documents
@@ -138,11 +138,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("DocumentManifest#DocumentManifest.related", IsNestedType=true)]
+        [FhirType("DocumentManifest#Related", IsNestedType=true)]
         [DataContract]
         public partial class RelatedComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedComponent"; } }
+            public override string TypeName { get { return "DocumentManifest#Related"; } }
             
             /// <summary>
             /// Identifiers of things that are related

--- a/src/Hl7.Fhir.Core/Model/Generated/DocumentReference.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DocumentReference.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "DocumentReference"; } }
         
-        [FhirType("DocumentReference#DocumentReference.relatesTo", IsNestedType=true)]
+        [FhirType("DocumentReference#RelatesTo", IsNestedType=true)]
         [DataContract]
         public partial class RelatesToComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatesToComponent"; } }
+            public override string TypeName { get { return "DocumentReference#RelatesTo"; } }
             
             /// <summary>
             /// replaces | transforms | signs | appends
@@ -175,11 +175,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("DocumentReference#DocumentReference.content", IsNestedType=true)]
+        [FhirType("DocumentReference#Content", IsNestedType=true)]
         [DataContract]
         public partial class ContentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContentComponent"; } }
+            public override string TypeName { get { return "DocumentReference#Content"; } }
             
             /// <summary>
             /// Where to access the document
@@ -277,11 +277,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("DocumentReference#DocumentReference.context", IsNestedType=true)]
+        [FhirType("DocumentReference#Context", IsNestedType=true)]
         [DataContract]
         public partial class ContextComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContextComponent"; } }
+            public override string TypeName { get { return "DocumentReference#Context"; } }
             
             /// <summary>
             /// Context of the document  content
@@ -474,11 +474,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("DocumentReference#DocumentReference.context.related", IsNestedType=true)]
+        [FhirType("DocumentReference#Related", IsNestedType=true)]
         [DataContract]
         public partial class RelatedComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedComponent"; } }
+            public override string TypeName { get { return "DocumentReference#Related"; } }
             
             /// <summary>
             /// Identifier of related objects or events

--- a/src/Hl7.Fhir.Core/Model/Generated/ElementDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ElementDefinition.cs
@@ -232,11 +232,11 @@ namespace Hl7.Fhir.Model
             Warning,
         }
 
-        [FhirType("ElementDefinition#ElementDefinition.slicing", IsNestedType=true)]
+        [FhirType("ElementDefinition#Slicing", IsNestedType=true)]
         [DataContract]
         public partial class SlicingComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "SlicingComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Slicing"; } }
             
             /// <summary>
             /// Element values that are used to distinguish the slices
@@ -422,11 +422,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.slicing.discriminator", IsNestedType=true)]
+        [FhirType("ElementDefinition#Discriminator", IsNestedType=true)]
         [DataContract]
         public partial class DiscriminatorComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "DiscriminatorComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Discriminator"; } }
             
             /// <summary>
             /// value | exists | pattern | type | profile
@@ -558,11 +558,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.base", IsNestedType=true)]
+        [FhirType("ElementDefinition#Base", IsNestedType=true)]
         [DataContract]
         public partial class BaseComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "BaseComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Base"; } }
             
             /// <summary>
             /// Path that identifies the base element
@@ -731,11 +731,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.type", IsNestedType=true)]
+        [FhirType("ElementDefinition#TypeRefComponent", IsNestedType=true)]
         [DataContract]
         public partial class TypeRefComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "TypeRefComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#TypeRefComponent"; } }
             
             /// <summary>
             /// Data type or Resource (reference to definition)
@@ -975,11 +975,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.example", IsNestedType=true)]
+        [FhirType("ElementDefinition#Example", IsNestedType=true)]
         [DataContract]
         public partial class ExampleComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "ExampleComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Example"; } }
             
             /// <summary>
             /// Describes the purpose of this example
@@ -1095,11 +1095,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.constraint", IsNestedType=true)]
+        [FhirType("ElementDefinition#Constraint", IsNestedType=true)]
         [DataContract]
         public partial class ConstraintComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "ConstraintComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Constraint"; } }
             
             /// <summary>
             /// Target of 'condition' reference above
@@ -1413,11 +1413,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.binding", IsNestedType=true)]
+        [FhirType("ElementDefinition#ElementDefinitionBindingComponent", IsNestedType=true)]
         [DataContract]
         public partial class ElementDefinitionBindingComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "ElementDefinitionBindingComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#ElementDefinitionBindingComponent"; } }
             
             /// <summary>
             /// required | extensible | preferred | example
@@ -1568,11 +1568,11 @@ namespace Hl7.Fhir.Model
             } 
             
         }                
-        [FhirType("ElementDefinition#ElementDefinition.mapping", IsNestedType=true)]
+        [FhirType("ElementDefinition#Mapping", IsNestedType=true)]
         [DataContract]
         public partial class MappingComponent : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "MappingComponent"; } }
+            public override string TypeName { get { return "ElementDefinition#Mapping"; } }
             
             /// <summary>
             /// Reference to mapping declaration

--- a/src/Hl7.Fhir.Core/Model/Generated/EligibilityResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EligibilityResponse.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "EligibilityResponse"; } }
         
-        [FhirType("EligibilityResponse#EligibilityResponse.insurance", IsNestedType=true)]
+        [FhirType("EligibilityResponse#Insurance", IsNestedType=true)]
         [DataContract]
         public partial class InsuranceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InsuranceComponent"; } }
+            public override string TypeName { get { return "EligibilityResponse#Insurance"; } }
             
             /// <summary>
             /// Updated Coverage details
@@ -176,11 +176,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("EligibilityResponse#EligibilityResponse.insurance.benefitBalance", IsNestedType=true)]
+        [FhirType("EligibilityResponse#Benefits", IsNestedType=true)]
         [DataContract]
         public partial class BenefitsComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BenefitsComponent"; } }
+            public override string TypeName { get { return "EligibilityResponse#Benefits"; } }
             
             /// <summary>
             /// Type of services covered
@@ -459,11 +459,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("EligibilityResponse#EligibilityResponse.insurance.benefitBalance.financial", IsNestedType=true)]
+        [FhirType("EligibilityResponse#Benefit", IsNestedType=true)]
         [DataContract]
         public partial class BenefitComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BenefitComponent"; } }
+            public override string TypeName { get { return "EligibilityResponse#Benefit"; } }
             
             /// <summary>
             /// Deductable, visits, benefit amount
@@ -583,11 +583,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("EligibilityResponse#EligibilityResponse.error", IsNestedType=true)]
+        [FhirType("EligibilityResponse#Errors", IsNestedType=true)]
         [DataContract]
         public partial class ErrorsComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ErrorsComponent"; } }
+            public override string TypeName { get { return "EligibilityResponse#Errors"; } }
             
             /// <summary>
             /// Error code detailing processing issues

--- a/src/Hl7.Fhir.Core/Model/Generated/Encounter.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Encounter.cs
@@ -148,11 +148,11 @@ namespace Hl7.Fhir.Model
             Completed,
         }
 
-        [FhirType("Encounter#Encounter.statusHistory", IsNestedType=true)]
+        [FhirType("Encounter#StatusHistory", IsNestedType=true)]
         [DataContract]
         public partial class StatusHistoryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StatusHistoryComponent"; } }
+            public override string TypeName { get { return "Encounter#StatusHistory"; } }
             
             /// <summary>
             /// planned | arrived | triaged | in-progress | onleave | finished | cancelled +
@@ -269,11 +269,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Encounter#Encounter.classHistory", IsNestedType=true)]
+        [FhirType("Encounter#ClassHistory", IsNestedType=true)]
         [DataContract]
         public partial class ClassHistoryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ClassHistoryComponent"; } }
+            public override string TypeName { get { return "Encounter#ClassHistory"; } }
             
             /// <summary>
             /// inpatient | outpatient | ambulatory | emergency +
@@ -372,11 +372,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Encounter#Encounter.participant", IsNestedType=true)]
+        [FhirType("Encounter#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "Encounter#Participant"; } }
             
             /// <summary>
             /// Role of participant in encounter
@@ -494,11 +494,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Encounter#Encounter.diagnosis", IsNestedType=true)]
+        [FhirType("Encounter#Diagnosis", IsNestedType=true)]
         [DataContract]
         public partial class DiagnosisComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DiagnosisComponent"; } }
+            public override string TypeName { get { return "Encounter#Diagnosis"; } }
             
             /// <summary>
             /// Reason the encounter takes place (resource)
@@ -634,11 +634,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Encounter#Encounter.hospitalization", IsNestedType=true)]
+        [FhirType("Encounter#Hospitalization", IsNestedType=true)]
         [DataContract]
         public partial class HospitalizationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "HospitalizationComponent"; } }
+            public override string TypeName { get { return "Encounter#Hospitalization"; } }
             
             /// <summary>
             /// Pre-admission identifier
@@ -868,11 +868,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Encounter#Encounter.location", IsNestedType=true)]
+        [FhirType("Encounter#Location", IsNestedType=true)]
         [DataContract]
         public partial class LocationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LocationComponent"; } }
+            public override string TypeName { get { return "Encounter#Location"; } }
             
             /// <summary>
             /// Location the encounter takes place

--- a/src/Hl7.Fhir.Core/Model/Generated/EpisodeOfCare.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EpisodeOfCare.cs
@@ -103,11 +103,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("EpisodeOfCare#EpisodeOfCare.statusHistory", IsNestedType=true)]
+        [FhirType("EpisodeOfCare#StatusHistory", IsNestedType=true)]
         [DataContract]
         public partial class StatusHistoryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StatusHistoryComponent"; } }
+            public override string TypeName { get { return "EpisodeOfCare#StatusHistory"; } }
             
             /// <summary>
             /// planned | waitlist | active | onhold | finished | cancelled | entered-in-error
@@ -224,11 +224,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("EpisodeOfCare#EpisodeOfCare.diagnosis", IsNestedType=true)]
+        [FhirType("EpisodeOfCare#Diagnosis", IsNestedType=true)]
         [DataContract]
         public partial class DiagnosisComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DiagnosisComponent"; } }
+            public override string TypeName { get { return "EpisodeOfCare#Diagnosis"; } }
             
             /// <summary>
             /// Conditions/problems/diagnoses this episode of care is for

--- a/src/Hl7.Fhir.Core/Model/Generated/ExpansionProfile.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ExpansionProfile.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             Override,
         }
 
-        [FhirType("ExpansionProfile#ExpansionProfile.fixedVersion", IsNestedType=true)]
+        [FhirType("ExpansionProfile#FixedVersion", IsNestedType=true)]
         [DataContract]
         public partial class FixedVersionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FixedVersionComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#FixedVersion"; } }
             
             /// <summary>
             /// System to have its version fixed
@@ -255,11 +255,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.excludedSystem", IsNestedType=true)]
+        [FhirType("ExpansionProfile#ExcludedSystem", IsNestedType=true)]
         [DataContract]
         public partial class ExcludedSystemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExcludedSystemComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#ExcludedSystem"; } }
             
             /// <summary>
             /// The specific code system to be excluded
@@ -393,11 +393,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.designation", IsNestedType=true)]
+        [FhirType("ExpansionProfile#Designation", IsNestedType=true)]
         [DataContract]
         public partial class DesignationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#Designation"; } }
             
             /// <summary>
             /// Designations to be included
@@ -494,11 +494,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.designation.include", IsNestedType=true)]
+        [FhirType("ExpansionProfile#DesignationInclude", IsNestedType=true)]
         [DataContract]
         public partial class DesignationIncludeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationIncludeComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#DesignationInclude"; } }
             
             /// <summary>
             /// The designation to be included
@@ -578,11 +578,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.designation.include.designation", IsNestedType=true)]
+        [FhirType("ExpansionProfile#DesignationIncludeDesignation", IsNestedType=true)]
         [DataContract]
         public partial class DesignationIncludeDesignationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationIncludeDesignationComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#DesignationIncludeDesignation"; } }
             
             /// <summary>
             /// Human language of the designation to be included
@@ -697,11 +697,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.designation.exclude", IsNestedType=true)]
+        [FhirType("ExpansionProfile#DesignationExclude", IsNestedType=true)]
         [DataContract]
         public partial class DesignationExcludeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationExcludeComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#DesignationExclude"; } }
             
             /// <summary>
             /// The designation to be excluded
@@ -781,11 +781,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExpansionProfile#ExpansionProfile.designation.exclude.designation", IsNestedType=true)]
+        [FhirType("ExpansionProfile#DesignationExcludeDesignation", IsNestedType=true)]
         [DataContract]
         public partial class DesignationExcludeDesignationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationExcludeDesignationComponent"; } }
+            public override string TypeName { get { return "ExpansionProfile#DesignationExcludeDesignation"; } }
             
             /// <summary>
             /// Human language of the designation to be excluded

--- a/src/Hl7.Fhir.Core/Model/Generated/ExplanationOfBenefit.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ExplanationOfBenefit.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.related", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#RelatedClaim", IsNestedType=true)]
         [DataContract]
         public partial class RelatedClaimComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedClaimComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#RelatedClaim"; } }
             
             /// <summary>
             /// Reference to the related claim
@@ -206,11 +206,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.payee", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Payee", IsNestedType=true)]
         [DataContract]
         public partial class PayeeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PayeeComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Payee"; } }
             
             /// <summary>
             /// Type of party: Subscriber, Provider, other
@@ -327,11 +327,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.information", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#SupportingInformation", IsNestedType=true)]
         [DataContract]
         public partial class SupportingInformationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SupportingInformationComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#SupportingInformation"; } }
             
             /// <summary>
             /// Information instance identifier
@@ -524,11 +524,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.careTeam", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#CareTeam", IsNestedType=true)]
         [DataContract]
         public partial class CareTeamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CareTeamComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#CareTeam"; } }
             
             /// <summary>
             /// Number to covey order of careteam
@@ -719,11 +719,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.diagnosis", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Diagnosis", IsNestedType=true)]
         [DataContract]
         public partial class DiagnosisComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DiagnosisComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Diagnosis"; } }
             
             /// <summary>
             /// Number to covey order of diagnosis
@@ -879,11 +879,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.procedure", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Procedure", IsNestedType=true)]
         [DataContract]
         public partial class ProcedureComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProcedureComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Procedure"; } }
             
             /// <summary>
             /// Procedure sequence for reference
@@ -1038,11 +1038,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.insurance", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Insurance", IsNestedType=true)]
         [DataContract]
         public partial class InsuranceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InsuranceComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Insurance"; } }
             
             /// <summary>
             /// Insurance information
@@ -1160,11 +1160,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.accident", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Accident", IsNestedType=true)]
         [DataContract]
         public partial class AccidentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AccidentComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Accident"; } }
             
             /// <summary>
             /// When the accident occurred
@@ -1299,11 +1299,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.item", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Item"; } }
             
             /// <summary>
             /// Service instance
@@ -1925,11 +1925,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.item.adjudication", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Adjudication", IsNestedType=true)]
         [DataContract]
         public partial class AdjudicationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AdjudicationComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Adjudication"; } }
             
             /// <summary>
             /// Adjudication category such as co-pay, eligible, benefit, etc.
@@ -2081,11 +2081,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.item.detail", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Detail", IsNestedType=true)]
         [DataContract]
         public partial class DetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DetailComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Detail"; } }
             
             /// <summary>
             /// Service instance
@@ -2480,11 +2480,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.item.detail.subDetail", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#SubDetail", IsNestedType=true)]
         [DataContract]
         public partial class SubDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SubDetailComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#SubDetail"; } }
             
             /// <summary>
             /// Service instance
@@ -2860,11 +2860,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.addItem", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#AddedItem", IsNestedType=true)]
         [DataContract]
         public partial class AddedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AddedItemComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#AddedItem"; } }
             
             /// <summary>
             /// Service instances
@@ -3128,11 +3128,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.addItem.detail", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#AddedItemsDetail", IsNestedType=true)]
         [DataContract]
         public partial class AddedItemsDetailComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AddedItemsDetailComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#AddedItemsDetail"; } }
             
             /// <summary>
             /// Revenue or cost center code
@@ -3340,11 +3340,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.payment", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Payment", IsNestedType=true)]
         [DataContract]
         public partial class PaymentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PaymentComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Payment"; } }
             
             /// <summary>
             /// Partial or Complete
@@ -3531,11 +3531,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.processNote", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Note", IsNestedType=true)]
         [DataContract]
         public partial class NoteComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NoteComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Note"; } }
             
             /// <summary>
             /// Sequence number for this note
@@ -3704,11 +3704,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.benefitBalance", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#BenefitBalance", IsNestedType=true)]
         [DataContract]
         public partial class BenefitBalanceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BenefitBalanceComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#BenefitBalance"; } }
             
             /// <summary>
             /// Type of services covered
@@ -3987,11 +3987,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ExplanationOfBenefit#ExplanationOfBenefit.benefitBalance.financial", IsNestedType=true)]
+        [FhirType("ExplanationOfBenefit#Benefit", IsNestedType=true)]
         [DataContract]
         public partial class BenefitComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BenefitComponent"; } }
+            public override string TypeName { get { return "ExplanationOfBenefit#Benefit"; } }
             
             /// <summary>
             /// Deductable, visits, benefit amount

--- a/src/Hl7.Fhir.Core/Model/Generated/FamilyMemberHistory.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/FamilyMemberHistory.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             HealthUnknown,
         }
 
-        [FhirType("FamilyMemberHistory#FamilyMemberHistory.condition", IsNestedType=true)]
+        [FhirType("FamilyMemberHistory#Condition", IsNestedType=true)]
         [DataContract]
         public partial class ConditionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConditionComponent"; } }
+            public override string TypeName { get { return "FamilyMemberHistory#Condition"; } }
             
             /// <summary>
             /// Condition suffered by relation

--- a/src/Hl7.Fhir.Core/Model/Generated/Goal.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Goal.cs
@@ -139,11 +139,11 @@ namespace Hl7.Fhir.Model
             Rejected,
         }
 
-        [FhirType("Goal#Goal.target", IsNestedType=true)]
+        [FhirType("Goal#Target", IsNestedType=true)]
         [DataContract]
         public partial class TargetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TargetComponent"; } }
+            public override string TypeName { get { return "Goal#Target"; } }
             
             /// <summary>
             /// The parameter whose value is being tracked

--- a/src/Hl7.Fhir.Core/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/GraphDefinition.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             Custom,
         }
 
-        [FhirType("GraphDefinition#GraphDefinition.link", IsNestedType=true)]
+        [FhirType("GraphDefinition#Link", IsNestedType=true)]
         [DataContract]
         public partial class LinkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LinkComponent"; } }
+            public override string TypeName { get { return "GraphDefinition#Link"; } }
             
             /// <summary>
             /// Path in the resource that contains the link
@@ -350,11 +350,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("GraphDefinition#GraphDefinition.link.target", IsNestedType=true)]
+        [FhirType("GraphDefinition#Target", IsNestedType=true)]
         [DataContract]
         public partial class TargetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TargetComponent"; } }
+            public override string TypeName { get { return "GraphDefinition#Target"; } }
             
             /// <summary>
             /// Type of resource this link refers to
@@ -526,11 +526,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("GraphDefinition#GraphDefinition.link.target.compartment", IsNestedType=true)]
+        [FhirType("GraphDefinition#Compartment", IsNestedType=true)]
         [DataContract]
         public partial class CompartmentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CompartmentComponent"; } }
+            public override string TypeName { get { return "GraphDefinition#Compartment"; } }
             
             /// <summary>
             /// Identifies the compartment

--- a/src/Hl7.Fhir.Core/Model/Generated/Group.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Group.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             Substance,
         }
 
-        [FhirType("Group#Group.characteristic", IsNestedType=true)]
+        [FhirType("Group#Characteristic", IsNestedType=true)]
         [DataContract]
         public partial class CharacteristicComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CharacteristicComponent"; } }
+            public override string TypeName { get { return "Group#Characteristic"; } }
             
             /// <summary>
             /// Kind of characteristic
@@ -257,11 +257,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Group#Group.member", IsNestedType=true)]
+        [FhirType("Group#Member", IsNestedType=true)]
         [DataContract]
         public partial class MemberComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MemberComponent"; } }
+            public override string TypeName { get { return "Group#Member"; } }
             
             /// <summary>
             /// Reference to the group member

--- a/src/Hl7.Fhir.Core/Model/Generated/HealthcareService.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/HealthcareService.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "HealthcareService"; } }
         
-        [FhirType("HealthcareService#HealthcareService.availableTime", IsNestedType=true)]
+        [FhirType("HealthcareService#AvailableTime", IsNestedType=true)]
         [DataContract]
         public partial class AvailableTimeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AvailableTimeComponent"; } }
+            public override string TypeName { get { return "HealthcareService#AvailableTime"; } }
             
             /// <summary>
             /// mon | tue | wed | thu | fri | sat | sun
@@ -262,11 +262,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("HealthcareService#HealthcareService.notAvailable", IsNestedType=true)]
+        [FhirType("HealthcareService#NotAvailable", IsNestedType=true)]
         [DataContract]
         public partial class NotAvailableComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NotAvailableComponent"; } }
+            public override string TypeName { get { return "HealthcareService#NotAvailable"; } }
             
             /// <summary>
             /// Reason presented to the user explaining why time not available

--- a/src/Hl7.Fhir.Core/Model/Generated/ImagingManifest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImagingManifest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ImagingManifest"; } }
         
-        [FhirType("ImagingManifest#ImagingManifest.study", IsNestedType=true)]
+        [FhirType("ImagingManifest#Study", IsNestedType=true)]
         [DataContract]
         public partial class StudyComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StudyComponent"; } }
+            public override string TypeName { get { return "ImagingManifest#Study"; } }
             
             /// <summary>
             /// Study instance UID
@@ -214,11 +214,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImagingManifest#ImagingManifest.study.series", IsNestedType=true)]
+        [FhirType("ImagingManifest#Series", IsNestedType=true)]
         [DataContract]
         public partial class SeriesComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SeriesComponent"; } }
+            public override string TypeName { get { return "ImagingManifest#Series"; } }
             
             /// <summary>
             /// Series instance UID
@@ -356,11 +356,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImagingManifest#ImagingManifest.study.series.instance", IsNestedType=true)]
+        [FhirType("ImagingManifest#Instance", IsNestedType=true)]
         [DataContract]
         public partial class InstanceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InstanceComponent"; } }
+            public override string TypeName { get { return "ImagingManifest#Instance"; } }
             
             /// <summary>
             /// SOP class UID of instance

--- a/src/Hl7.Fhir.Core/Model/Generated/ImagingStudy.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImagingStudy.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             UNAVAILABLE,
         }
 
-        [FhirType("ImagingStudy#ImagingStudy.series", IsNestedType=true)]
+        [FhirType("ImagingStudy#Series", IsNestedType=true)]
         [DataContract]
         public partial class SeriesComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SeriesComponent"; } }
+            public override string TypeName { get { return "ImagingStudy#Series"; } }
             
             /// <summary>
             /// Formal DICOM identifier for this series
@@ -483,11 +483,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImagingStudy#ImagingStudy.series.instance", IsNestedType=true)]
+        [FhirType("ImagingStudy#Instance", IsNestedType=true)]
         [DataContract]
         public partial class InstanceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InstanceComponent"; } }
+            public override string TypeName { get { return "ImagingStudy#Instance"; } }
             
             /// <summary>
             /// Formal DICOM identifier for this instance

--- a/src/Hl7.Fhir.Core/Model/Generated/Immunization.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Immunization.cs
@@ -73,11 +73,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Immunization#Immunization.practitioner", IsNestedType=true)]
+        [FhirType("Immunization#Practitioner", IsNestedType=true)]
         [DataContract]
         public partial class PractitionerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PractitionerComponent"; } }
+            public override string TypeName { get { return "Immunization#Practitioner"; } }
             
             /// <summary>
             /// What type of performance was done
@@ -177,11 +177,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Immunization#Immunization.explanation", IsNestedType=true)]
+        [FhirType("Immunization#Explanation", IsNestedType=true)]
         [DataContract]
         public partial class ExplanationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExplanationComponent"; } }
+            public override string TypeName { get { return "Immunization#Explanation"; } }
             
             /// <summary>
             /// Why immunization occurred
@@ -280,11 +280,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Immunization#Immunization.reaction", IsNestedType=true)]
+        [FhirType("Immunization#Reaction", IsNestedType=true)]
         [DataContract]
         public partial class ReactionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ReactionComponent"; } }
+            public override string TypeName { get { return "Immunization#Reaction"; } }
             
             /// <summary>
             /// When reaction started
@@ -437,11 +437,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Immunization#Immunization.vaccinationProtocol", IsNestedType=true)]
+        [FhirType("Immunization#VaccinationProtocol", IsNestedType=true)]
         [DataContract]
         public partial class VaccinationProtocolComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "VaccinationProtocolComponent"; } }
+            public override string TypeName { get { return "Immunization#VaccinationProtocol"; } }
             
             /// <summary>
             /// Dose number within series

--- a/src/Hl7.Fhir.Core/Model/Generated/ImmunizationRecommendation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImmunizationRecommendation.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ImmunizationRecommendation"; } }
         
-        [FhirType("ImmunizationRecommendation#ImmunizationRecommendation.recommendation", IsNestedType=true)]
+        [FhirType("ImmunizationRecommendation#Recommendation", IsNestedType=true)]
         [DataContract]
         public partial class RecommendationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RecommendationComponent"; } }
+            public override string TypeName { get { return "ImmunizationRecommendation#Recommendation"; } }
             
             /// <summary>
             /// Date recommendation created
@@ -324,11 +324,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImmunizationRecommendation#ImmunizationRecommendation.recommendation.dateCriterion", IsNestedType=true)]
+        [FhirType("ImmunizationRecommendation#DateCriterion", IsNestedType=true)]
         [DataContract]
         public partial class DateCriterionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DateCriterionComponent"; } }
+            public override string TypeName { get { return "ImmunizationRecommendation#DateCriterion"; } }
             
             /// <summary>
             /// Type of date
@@ -445,11 +445,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImmunizationRecommendation#ImmunizationRecommendation.recommendation.protocol", IsNestedType=true)]
+        [FhirType("ImmunizationRecommendation#Protocol", IsNestedType=true)]
         [DataContract]
         public partial class ProtocolComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProtocolComponent"; } }
+            public override string TypeName { get { return "ImmunizationRecommendation#Protocol"; } }
             
             /// <summary>
             /// Dose number within sequence

--- a/src/Hl7.Fhir.Core/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImplementationGuide.cs
@@ -130,11 +130,11 @@ namespace Hl7.Fhir.Model
             Resource,
         }
 
-        [FhirType("ImplementationGuide#ImplementationGuide.dependency", IsNestedType=true)]
+        [FhirType("ImplementationGuide#Dependency", IsNestedType=true)]
         [DataContract]
         public partial class DependencyComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DependencyComponent"; } }
+            public override string TypeName { get { return "ImplementationGuide#Dependency"; } }
             
             /// <summary>
             /// reference | inclusion
@@ -269,11 +269,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImplementationGuide#ImplementationGuide.package", IsNestedType=true)]
+        [FhirType("ImplementationGuide#Package", IsNestedType=true)]
         [DataContract]
         public partial class PackageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PackageComponent"; } }
+            public override string TypeName { get { return "ImplementationGuide#Package"; } }
             
             /// <summary>
             /// Name used .page.package
@@ -426,11 +426,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImplementationGuide#ImplementationGuide.package.resource", IsNestedType=true)]
+        [FhirType("ImplementationGuide#Resource", IsNestedType=true)]
         [DataContract]
         public partial class ResourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResourceComponent"; } }
+            public override string TypeName { get { return "ImplementationGuide#Resource"; } }
             
             /// <summary>
             /// If not an example, has its normal meaning
@@ -677,11 +677,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImplementationGuide#ImplementationGuide.global", IsNestedType=true)]
+        [FhirType("ImplementationGuide#Global", IsNestedType=true)]
         [DataContract]
         public partial class GlobalComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GlobalComponent"; } }
+            public override string TypeName { get { return "ImplementationGuide#Global"; } }
             
             /// <summary>
             /// Type this profiles applies to
@@ -800,11 +800,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ImplementationGuide#ImplementationGuide.page", IsNestedType=true)]
+        [FhirType("ImplementationGuide#Page", IsNestedType=true)]
         [DataContract]
         public partial class PageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PageComponent"; } }
+            public override string TypeName { get { return "ImplementationGuide#Page"; } }
             
             /// <summary>
             /// Where to find that page

--- a/src/Hl7.Fhir.Core/Model/Generated/Linkage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Linkage.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             Historical,
         }
 
-        [FhirType("Linkage#Linkage.item", IsNestedType=true)]
+        [FhirType("Linkage#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "Linkage#Item"; } }
             
             /// <summary>
             /// source | alternate | historical

--- a/src/Hl7.Fhir.Core/Model/Generated/List.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/List.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("List#List.entry", IsNestedType=true)]
+        [FhirType("List#Entry", IsNestedType=true)]
         [DataContract]
         public partial class EntryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EntryComponent"; } }
+            public override string TypeName { get { return "List#Entry"; } }
             
             /// <summary>
             /// Status/Workflow information about this item

--- a/src/Hl7.Fhir.Core/Model/Generated/Location.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Location.cs
@@ -100,11 +100,11 @@ namespace Hl7.Fhir.Model
             Kind,
         }
 
-        [FhirType("Location#Location.position", IsNestedType=true)]
+        [FhirType("Location#Position", IsNestedType=true)]
         [DataContract]
         public partial class PositionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PositionComponent"; } }
+            public override string TypeName { get { return "Location#Position"; } }
             
             /// <summary>
             /// Longitude with WGS84 datum

--- a/src/Hl7.Fhir.Core/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Measure.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Measure"; } }
         
-        [FhirType("Measure#Measure.group", IsNestedType=true)]
+        [FhirType("Measure#Group", IsNestedType=true)]
         [DataContract]
         public partial class GroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GroupComponent"; } }
+            public override string TypeName { get { return "Measure#Group"; } }
             
             /// <summary>
             /// Unique identifier
@@ -246,11 +246,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Measure#Measure.group.population", IsNestedType=true)]
+        [FhirType("Measure#Population", IsNestedType=true)]
         [DataContract]
         public partial class PopulationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PopulationComponent"; } }
+            public override string TypeName { get { return "Measure#Population"; } }
             
             /// <summary>
             /// Unique identifier
@@ -456,11 +456,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Measure#Measure.group.stratifier", IsNestedType=true)]
+        [FhirType("Measure#Stratifier", IsNestedType=true)]
         [DataContract]
         public partial class StratifierComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StratifierComponent"; } }
+            public override string TypeName { get { return "Measure#Stratifier"; } }
             
             /// <summary>
             /// The identifier for the stratifier used to coordinate the reported data back to this stratifier
@@ -611,11 +611,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Measure#Measure.supplementalData", IsNestedType=true)]
+        [FhirType("Measure#SupplementalData", IsNestedType=true)]
         [DataContract]
         public partial class SupplementalDataComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SupplementalDataComponent"; } }
+            public override string TypeName { get { return "Measure#SupplementalData"; } }
             
             /// <summary>
             /// Identifier, unique within the measure

--- a/src/Hl7.Fhir.Core/Model/Generated/MeasureReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MeasureReport.cs
@@ -106,11 +106,11 @@ namespace Hl7.Fhir.Model
             Summary,
         }
 
-        [FhirType("MeasureReport#MeasureReport.group", IsNestedType=true)]
+        [FhirType("MeasureReport#Group", IsNestedType=true)]
         [DataContract]
         public partial class GroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GroupComponent"; } }
+            public override string TypeName { get { return "MeasureReport#Group"; } }
             
             /// <summary>
             /// What group of the measure
@@ -264,11 +264,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MeasureReport#MeasureReport.group.population", IsNestedType=true)]
+        [FhirType("MeasureReport#Population", IsNestedType=true)]
         [DataContract]
         public partial class PopulationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PopulationComponent"; } }
+            public override string TypeName { get { return "MeasureReport#Population"; } }
             
             /// <summary>
             /// Population identifier as defined in the measure
@@ -421,11 +421,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MeasureReport#MeasureReport.group.stratifier", IsNestedType=true)]
+        [FhirType("MeasureReport#Stratifier", IsNestedType=true)]
         [DataContract]
         public partial class StratifierComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StratifierComponent"; } }
+            public override string TypeName { get { return "MeasureReport#Stratifier"; } }
             
             /// <summary>
             /// What stratifier of the group
@@ -523,11 +523,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MeasureReport#MeasureReport.group.stratifier.stratum", IsNestedType=true)]
+        [FhirType("MeasureReport#StratifierGroup", IsNestedType=true)]
         [DataContract]
         public partial class StratifierGroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StratifierGroupComponent"; } }
+            public override string TypeName { get { return "MeasureReport#StratifierGroup"; } }
             
             /// <summary>
             /// The stratum value, e.g. male
@@ -680,11 +680,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MeasureReport#MeasureReport.group.stratifier.stratum.population", IsNestedType=true)]
+        [FhirType("MeasureReport#StratifierGroupPopulation", IsNestedType=true)]
         [DataContract]
         public partial class StratifierGroupPopulationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StratifierGroupPopulationComponent"; } }
+            public override string TypeName { get { return "MeasureReport#StratifierGroupPopulation"; } }
             
             /// <summary>
             /// Population identifier as defined in the measure

--- a/src/Hl7.Fhir.Core/Model/Generated/Medication.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Medication.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Medication#Medication.ingredient", IsNestedType=true)]
+        [FhirType("Medication#Ingredient", IsNestedType=true)]
         [DataContract]
         public partial class IngredientComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "IngredientComponent"; } }
+            public override string TypeName { get { return "Medication#Ingredient"; } }
             
             /// <summary>
             /// The product contained
@@ -219,11 +219,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Medication#Medication.package", IsNestedType=true)]
+        [FhirType("Medication#Package", IsNestedType=true)]
         [DataContract]
         public partial class PackageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PackageComponent"; } }
+            public override string TypeName { get { return "Medication#Package"; } }
             
             /// <summary>
             /// E.g. box, vial, blister-pack
@@ -340,11 +340,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Medication#Medication.package.content", IsNestedType=true)]
+        [FhirType("Medication#Content", IsNestedType=true)]
         [DataContract]
         public partial class ContentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContentComponent"; } }
+            public override string TypeName { get { return "Medication#Content"; } }
             
             /// <summary>
             /// The item in the package
@@ -444,11 +444,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Medication#Medication.package.batch", IsNestedType=true)]
+        [FhirType("Medication#Batch", IsNestedType=true)]
         [DataContract]
         public partial class BatchComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BatchComponent"; } }
+            public override string TypeName { get { return "Medication#Batch"; } }
             
             /// <summary>
             /// Identifier assigned to batch

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationAdministration.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationAdministration.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("MedicationAdministration#MedicationAdministration.performer", IsNestedType=true)]
+        [FhirType("MedicationAdministration#Performer", IsNestedType=true)]
         [DataContract]
         public partial class PerformerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PerformerComponent"; } }
+            public override string TypeName { get { return "MedicationAdministration#Performer"; } }
             
             /// <summary>
             /// Individual who was performing
@@ -203,11 +203,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MedicationAdministration#MedicationAdministration.dosage", IsNestedType=true)]
+        [FhirType("MedicationAdministration#Dosage", IsNestedType=true)]
         [DataContract]
         public partial class DosageComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DosageComponent"; } }
+            public override string TypeName { get { return "MedicationAdministration#Dosage"; } }
             
             /// <summary>
             /// Free text dosage instructions e.g. SIG

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationDispense.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationDispense.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             Stopped,
         }
 
-        [FhirType("MedicationDispense#MedicationDispense.performer", IsNestedType=true)]
+        [FhirType("MedicationDispense#Performer", IsNestedType=true)]
         [DataContract]
         public partial class PerformerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PerformerComponent"; } }
+            public override string TypeName { get { return "MedicationDispense#Performer"; } }
             
             /// <summary>
             /// Individual who was performing
@@ -203,11 +203,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MedicationDispense#MedicationDispense.substitution", IsNestedType=true)]
+        [FhirType("MedicationDispense#Substitution", IsNestedType=true)]
         [DataContract]
         public partial class SubstitutionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SubstitutionComponent"; } }
+            public override string TypeName { get { return "MedicationDispense#Substitution"; } }
             
             /// <summary>
             /// Whether a substitution was or was not performed on the dispense

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationRequest.cs
@@ -175,11 +175,11 @@ namespace Hl7.Fhir.Model
             Asap,
         }
 
-        [FhirType("MedicationRequest#MedicationRequest.requester", IsNestedType=true)]
+        [FhirType("MedicationRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "MedicationRequest#Requester"; } }
             
             /// <summary>
             /// Who ordered the initial medication(s)
@@ -281,11 +281,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MedicationRequest#MedicationRequest.dispenseRequest", IsNestedType=true)]
+        [FhirType("MedicationRequest#DispenseRequest", IsNestedType=true)]
         [DataContract]
         public partial class DispenseRequestComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DispenseRequestComponent"; } }
+            public override string TypeName { get { return "MedicationRequest#DispenseRequest"; } }
             
             /// <summary>
             /// Time period supply is authorized for
@@ -456,11 +456,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MedicationRequest#MedicationRequest.substitution", IsNestedType=true)]
+        [FhirType("MedicationRequest#Substitution", IsNestedType=true)]
         [DataContract]
         public partial class SubstitutionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SubstitutionComponent"; } }
+            public override string TypeName { get { return "MedicationRequest#Substitution"; } }
             
             /// <summary>
             /// Whether substitution is allowed or not

--- a/src/Hl7.Fhir.Core/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MessageDefinition.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "MessageDefinition"; } }
         
-        [FhirType("MessageDefinition#MessageDefinition.focus", IsNestedType=true)]
+        [FhirType("MessageDefinition#Focus", IsNestedType=true)]
         [DataContract]
         public partial class FocusComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FocusComponent"; } }
+            public override string TypeName { get { return "MessageDefinition#Focus"; } }
             
             /// <summary>
             /// Type of resource
@@ -246,11 +246,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MessageDefinition#MessageDefinition.allowedResponse", IsNestedType=true)]
+        [FhirType("MessageDefinition#AllowedResponse", IsNestedType=true)]
         [DataContract]
         public partial class AllowedResponseComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AllowedResponseComponent"; } }
+            public override string TypeName { get { return "MessageDefinition#AllowedResponse"; } }
             
             /// <summary>
             /// Reference to allowed message definition response

--- a/src/Hl7.Fhir.Core/Model/Generated/MessageHeader.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MessageHeader.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             FatalError,
         }
 
-        [FhirType("MessageHeader#MessageHeader.destination", IsNestedType=true)]
+        [FhirType("MessageHeader#MessageDestination", IsNestedType=true)]
         [DataContract]
         public partial class MessageDestinationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MessageDestinationComponent"; } }
+            public override string TypeName { get { return "MessageHeader#MessageDestination"; } }
             
             /// <summary>
             /// Name of system
@@ -237,11 +237,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MessageHeader#MessageHeader.source", IsNestedType=true)]
+        [FhirType("MessageHeader#MessageSource", IsNestedType=true)]
         [DataContract]
         public partial class MessageSourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MessageSourceComponent"; } }
+            public override string TypeName { get { return "MessageHeader#MessageSource"; } }
             
             /// <summary>
             /// Name of system
@@ -465,11 +465,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("MessageHeader#MessageHeader.response", IsNestedType=true)]
+        [FhirType("MessageHeader#Response", IsNestedType=true)]
         [DataContract]
         public partial class ResponseComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ResponseComponent"; } }
+            public override string TypeName { get { return "MessageHeader#Response"; } }
             
             /// <summary>
             /// Id of original message

--- a/src/Hl7.Fhir.Core/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NamingSystem.cs
@@ -112,11 +112,11 @@ namespace Hl7.Fhir.Model
             Other,
         }
 
-        [FhirType("NamingSystem#NamingSystem.uniqueId", IsNestedType=true)]
+        [FhirType("NamingSystem#UniqueId", IsNestedType=true)]
         [DataContract]
         public partial class UniqueIdComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "UniqueIdComponent"; } }
+            public override string TypeName { get { return "NamingSystem#UniqueId"; } }
             
             /// <summary>
             /// oid | uuid | uri | other

--- a/src/Hl7.Fhir.Core/Model/Generated/NutritionOrder.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NutritionOrder.cs
@@ -115,11 +115,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("NutritionOrder#NutritionOrder.oralDiet", IsNestedType=true)]
+        [FhirType("NutritionOrder#OralDiet", IsNestedType=true)]
         [DataContract]
         public partial class OralDietComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OralDietComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#OralDiet"; } }
             
             /// <summary>
             /// Type of oral diet or diet restrictions that describe what can be consumed orally
@@ -311,11 +311,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("NutritionOrder#NutritionOrder.oralDiet.nutrient", IsNestedType=true)]
+        [FhirType("NutritionOrder#Nutrient", IsNestedType=true)]
         [DataContract]
         public partial class NutrientComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NutrientComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#Nutrient"; } }
             
             /// <summary>
             /// Type of nutrient that is being modified
@@ -412,11 +412,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("NutritionOrder#NutritionOrder.oralDiet.texture", IsNestedType=true)]
+        [FhirType("NutritionOrder#Texture", IsNestedType=true)]
         [DataContract]
         public partial class TextureComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TextureComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#Texture"; } }
             
             /// <summary>
             /// Code to indicate how to alter the texture of the foods, e.g. pureed
@@ -513,11 +513,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("NutritionOrder#NutritionOrder.supplement", IsNestedType=true)]
+        [FhirType("NutritionOrder#Supplement", IsNestedType=true)]
         [DataContract]
         public partial class SupplementComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SupplementComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#Supplement"; } }
             
             /// <summary>
             /// Type of supplement product requested
@@ -705,11 +705,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("NutritionOrder#NutritionOrder.enteralFormula", IsNestedType=true)]
+        [FhirType("NutritionOrder#EnteralFormula", IsNestedType=true)]
         [DataContract]
         public partial class EnteralFormulaComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EnteralFormulaComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#EnteralFormula"; } }
             
             /// <summary>
             /// Type of enteral or infant formula
@@ -987,11 +987,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("NutritionOrder#NutritionOrder.enteralFormula.administration", IsNestedType=true)]
+        [FhirType("NutritionOrder#Administration", IsNestedType=true)]
         [DataContract]
         public partial class AdministrationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AdministrationComponent"; } }
+            public override string TypeName { get { return "NutritionOrder#Administration"; } }
             
             /// <summary>
             /// Scheduled frequency of enteral feeding

--- a/src/Hl7.Fhir.Core/Model/Generated/Observation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Observation.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             InterferedBy,
         }
 
-        [FhirType("Observation#Observation.referenceRange", IsNestedType=true)]
+        [FhirType("Observation#ReferenceRange", IsNestedType=true)]
         [DataContract]
         public partial class ReferenceRangeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ReferenceRangeComponent"; } }
+            public override string TypeName { get { return "Observation#ReferenceRange"; } }
             
             /// <summary>
             /// Low Range, if relevant
@@ -289,11 +289,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Observation#Observation.related", IsNestedType=true)]
+        [FhirType("Observation#Related", IsNestedType=true)]
         [DataContract]
         public partial class RelatedComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedComponent"; } }
+            public override string TypeName { get { return "Observation#Related"; } }
             
             /// <summary>
             /// has-member | derived-from | sequel-to | replaces | qualified-by | interfered-by
@@ -411,11 +411,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Observation#Observation.component", IsNestedType=true)]
+        [FhirType("Observation#Component", IsNestedType=true)]
         [DataContract]
         public partial class ComponentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ComponentComponent"; } }
+            public override string TypeName { get { return "Observation#Component"; } }
             
             /// <summary>
             /// Type of component observation (code / type)

--- a/src/Hl7.Fhir.Core/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/OperationDefinition.cs
@@ -73,11 +73,11 @@ namespace Hl7.Fhir.Model
             Query,
         }
 
-        [FhirType("OperationDefinition#OperationDefinition.parameter", IsNestedType=true)]
+        [FhirType("OperationDefinition#Parameter", IsNestedType=true)]
         [DataContract]
         public partial class ParameterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParameterComponent"; } }
+            public override string TypeName { get { return "OperationDefinition#Parameter"; } }
             
             /// <summary>
             /// Name in Parameters.parameter.name or in URL
@@ -451,11 +451,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("OperationDefinition#OperationDefinition.parameter.binding", IsNestedType=true)]
+        [FhirType("OperationDefinition#Binding", IsNestedType=true)]
         [DataContract]
         public partial class BindingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "BindingComponent"; } }
+            public override string TypeName { get { return "OperationDefinition#Binding"; } }
             
             /// <summary>
             /// required | extensible | preferred | example
@@ -574,11 +574,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("OperationDefinition#OperationDefinition.overload", IsNestedType=true)]
+        [FhirType("OperationDefinition#Overload", IsNestedType=true)]
         [DataContract]
         public partial class OverloadComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OverloadComponent"; } }
+            public override string TypeName { get { return "OperationDefinition#Overload"; } }
             
             /// <summary>
             /// Name of parameter to include in overload

--- a/src/Hl7.Fhir.Core/Model/Generated/OperationOutcome.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/OperationOutcome.cs
@@ -268,11 +268,11 @@ namespace Hl7.Fhir.Model
             Informational,
         }
 
-        [FhirType("OperationOutcome#OperationOutcome.issue", IsNestedType=true)]
+        [FhirType("OperationOutcome#Issue", IsNestedType=true)]
         [DataContract]
         public partial class IssueComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "IssueComponent"; } }
+            public override string TypeName { get { return "OperationOutcome#Issue"; } }
             
             /// <summary>
             /// fatal | error | warning | information

--- a/src/Hl7.Fhir.Core/Model/Generated/Organization.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Organization.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Organization"; } }
         
-        [FhirType("Organization#Organization.contact", IsNestedType=true)]
+        [FhirType("Organization#Contact", IsNestedType=true)]
         [DataContract]
         public partial class ContactComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContactComponent"; } }
+            public override string TypeName { get { return "Organization#Contact"; } }
             
             /// <summary>
             /// The type of contact

--- a/src/Hl7.Fhir.Core/Model/Generated/Parameters.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Parameters.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Parameters"; } }
         
-        [FhirType("Parameters#Parameters.parameter", IsNestedType=true)]
+        [FhirType("Parameters#Parameter", IsNestedType=true)]
         [DataContract]
         public partial class ParameterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParameterComponent"; } }
+            public override string TypeName { get { return "Parameters#Parameter"; } }
             
             /// <summary>
             /// Name from the definition

--- a/src/Hl7.Fhir.Core/Model/Generated/Patient.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Patient.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             Seealso,
         }
 
-        [FhirType("Patient#Patient.contact", IsNestedType=true)]
+        [FhirType("Patient#Contact", IsNestedType=true)]
         [DataContract]
         public partial class ContactComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContactComponent"; } }
+            public override string TypeName { get { return "Patient#Contact"; } }
             
             /// <summary>
             /// The kind of relationship
@@ -298,11 +298,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Patient#Patient.animal", IsNestedType=true)]
+        [FhirType("Patient#Animal", IsNestedType=true)]
         [DataContract]
         public partial class AnimalComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AnimalComponent"; } }
+            public override string TypeName { get { return "Patient#Animal"; } }
             
             /// <summary>
             /// E.g. Dog, Cow
@@ -418,11 +418,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Patient#Patient.communication", IsNestedType=true)]
+        [FhirType("Patient#Communication", IsNestedType=true)]
         [DataContract]
         public partial class CommunicationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CommunicationComponent"; } }
+            public override string TypeName { get { return "Patient#Communication"; } }
             
             /// <summary>
             /// The language which can be used to communicate with the patient about his or her health
@@ -538,11 +538,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Patient#Patient.link", IsNestedType=true)]
+        [FhirType("Patient#Link", IsNestedType=true)]
         [DataContract]
         public partial class LinkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LinkComponent"; } }
+            public override string TypeName { get { return "Patient#Link"; } }
             
             /// <summary>
             /// The other patient or related person resource that the link refers to

--- a/src/Hl7.Fhir.Core/Model/Generated/PaymentReconciliation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PaymentReconciliation.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "PaymentReconciliation"; } }
         
-        [FhirType("PaymentReconciliation#PaymentReconciliation.detail", IsNestedType=true)]
+        [FhirType("PaymentReconciliation#Details", IsNestedType=true)]
         [DataContract]
         public partial class DetailsComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DetailsComponent"; } }
+            public override string TypeName { get { return "PaymentReconciliation#Details"; } }
             
             /// <summary>
             /// Type code
@@ -270,11 +270,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PaymentReconciliation#PaymentReconciliation.processNote", IsNestedType=true)]
+        [FhirType("PaymentReconciliation#Notes", IsNestedType=true)]
         [DataContract]
         public partial class NotesComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NotesComponent"; } }
+            public override string TypeName { get { return "PaymentReconciliation#Notes"; } }
             
             /// <summary>
             /// display | print | printoper

--- a/src/Hl7.Fhir.Core/Model/Generated/Person.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Person.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             Level4,
         }
 
-        [FhirType("Person#Person.link", IsNestedType=true)]
+        [FhirType("Person#Link", IsNestedType=true)]
         [DataContract]
         public partial class LinkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LinkComponent"; } }
+            public override string TypeName { get { return "Person#Link"; } }
             
             /// <summary>
             /// The resource to which this actual person is associated

--- a/src/Hl7.Fhir.Core/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PlanDefinition.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "PlanDefinition"; } }
         
-        [FhirType("PlanDefinition#PlanDefinition.goal", IsNestedType=true)]
+        [FhirType("PlanDefinition#Goal", IsNestedType=true)]
         [DataContract]
         public partial class GoalComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GoalComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#Goal"; } }
             
             /// <summary>
             /// E.g. Treatment, dietary, behavioral, etc
@@ -247,11 +247,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.goal.target", IsNestedType=true)]
+        [FhirType("PlanDefinition#Target", IsNestedType=true)]
         [DataContract]
         public partial class TargetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TargetComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#Target"; } }
             
             /// <summary>
             /// The parameter whose value is to be tracked
@@ -368,11 +368,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.action", IsNestedType=true)]
+        [FhirType("PlanDefinition#Action", IsNestedType=true)]
         [DataContract]
         public partial class ActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#Action"; } }
             
             /// <summary>
             /// User-visible label for the action (e.g. 1. or A.)
@@ -1081,11 +1081,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.action.condition", IsNestedType=true)]
+        [FhirType("PlanDefinition#Condition", IsNestedType=true)]
         [DataContract]
         public partial class ConditionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConditionComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#Condition"; } }
             
             /// <summary>
             /// applicability | start | stop
@@ -1291,11 +1291,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.action.relatedAction", IsNestedType=true)]
+        [FhirType("PlanDefinition#RelatedAction", IsNestedType=true)]
         [DataContract]
         public partial class RelatedActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedActionComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#RelatedAction"; } }
             
             /// <summary>
             /// What action is this related to
@@ -1450,11 +1450,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.action.participant", IsNestedType=true)]
+        [FhirType("PlanDefinition#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#Participant"; } }
             
             /// <summary>
             /// patient | practitioner | related-person
@@ -1570,11 +1570,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PlanDefinition#PlanDefinition.action.dynamicValue", IsNestedType=true)]
+        [FhirType("PlanDefinition#DynamicValue", IsNestedType=true)]
         [DataContract]
         public partial class DynamicValueComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DynamicValueComponent"; } }
+            public override string TypeName { get { return "PlanDefinition#DynamicValue"; } }
             
             /// <summary>
             /// Natural language description of the dynamic value

--- a/src/Hl7.Fhir.Core/Model/Generated/Practitioner.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Practitioner.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Practitioner"; } }
         
-        [FhirType("Practitioner#Practitioner.qualification", IsNestedType=true)]
+        [FhirType("Practitioner#Qualification", IsNestedType=true)]
         [DataContract]
         public partial class QualificationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "QualificationComponent"; } }
+            public override string TypeName { get { return "Practitioner#Qualification"; } }
             
             /// <summary>
             /// An identifier for this qualification for the practitioner

--- a/src/Hl7.Fhir.Core/Model/Generated/PractitionerRole.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PractitionerRole.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "PractitionerRole"; } }
         
-        [FhirType("PractitionerRole#PractitionerRole.availableTime", IsNestedType=true)]
+        [FhirType("PractitionerRole#AvailableTime", IsNestedType=true)]
         [DataContract]
         public partial class AvailableTimeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AvailableTimeComponent"; } }
+            public override string TypeName { get { return "PractitionerRole#AvailableTime"; } }
             
             /// <summary>
             /// mon | tue | wed | thu | fri | sat | sun
@@ -262,11 +262,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("PractitionerRole#PractitionerRole.notAvailable", IsNestedType=true)]
+        [FhirType("PractitionerRole#NotAvailable", IsNestedType=true)]
         [DataContract]
         public partial class NotAvailableComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "NotAvailableComponent"; } }
+            public override string TypeName { get { return "PractitionerRole#NotAvailable"; } }
             
             /// <summary>
             /// Reason presented to the user explaining why time not available

--- a/src/Hl7.Fhir.Core/Model/Generated/Procedure.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Procedure.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "Procedure"; } }
         
-        [FhirType("Procedure#Procedure.performer", IsNestedType=true)]
+        [FhirType("Procedure#Performer", IsNestedType=true)]
         [DataContract]
         public partial class PerformerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PerformerComponent"; } }
+            public override string TypeName { get { return "Procedure#Performer"; } }
             
             /// <summary>
             /// The role the actor was in
@@ -176,11 +176,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Procedure#Procedure.focalDevice", IsNestedType=true)]
+        [FhirType("Procedure#FocalDevice", IsNestedType=true)]
         [DataContract]
         public partial class FocalDeviceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FocalDeviceComponent"; } }
+            public override string TypeName { get { return "Procedure#FocalDevice"; } }
             
             /// <summary>
             /// Kind of change to device

--- a/src/Hl7.Fhir.Core/Model/Generated/ProcedureRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ProcedureRequest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ProcedureRequest"; } }
         
-        [FhirType("ProcedureRequest#ProcedureRequest.requester", IsNestedType=true)]
+        [FhirType("ProcedureRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "ProcedureRequest#Requester"; } }
             
             /// <summary>
             /// Individual making the request

--- a/src/Hl7.Fhir.Core/Model/Generated/ProcessRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ProcessRequest.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             Status,
         }
 
-        [FhirType("ProcessRequest#ProcessRequest.item", IsNestedType=true)]
+        [FhirType("ProcessRequest#Items", IsNestedType=true)]
         [DataContract]
         public partial class ItemsComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemsComponent"; } }
+            public override string TypeName { get { return "ProcessRequest#Items"; } }
             
             /// <summary>
             /// Service instance

--- a/src/Hl7.Fhir.Core/Model/Generated/ProcessResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ProcessResponse.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ProcessResponse"; } }
         
-        [FhirType("ProcessResponse#ProcessResponse.processNote", IsNestedType=true)]
+        [FhirType("ProcessResponse#ProcessNote", IsNestedType=true)]
         [DataContract]
         public partial class ProcessNoteComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProcessNoteComponent"; } }
+            public override string TypeName { get { return "ProcessResponse#ProcessNote"; } }
             
             /// <summary>
             /// display | print | printoper

--- a/src/Hl7.Fhir.Core/Model/Generated/Provenance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Provenance.cs
@@ -91,11 +91,11 @@ namespace Hl7.Fhir.Model
             Removal,
         }
 
-        [FhirType("Provenance#Provenance.agent", IsNestedType=true)]
+        [FhirType("Provenance#Agent", IsNestedType=true)]
         [DataContract]
         public partial class AgentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AgentComponent"; } }
+            public override string TypeName { get { return "Provenance#Agent"; } }
             
             /// <summary>
             /// What the agents role was
@@ -234,11 +234,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Provenance#Provenance.entity", IsNestedType=true)]
+        [FhirType("Provenance#Entity", IsNestedType=true)]
         [DataContract]
         public partial class EntityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EntityComponent"; } }
+            public override string TypeName { get { return "Provenance#Entity"; } }
             
             /// <summary>
             /// derivation | revision | quotation | source | removal

--- a/src/Hl7.Fhir.Core/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Questionnaire.cs
@@ -157,11 +157,11 @@ namespace Hl7.Fhir.Model
             Quantity,
         }
 
-        [FhirType("Questionnaire#Questionnaire.item", IsNestedType=true)]
+        [FhirType("Questionnaire#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "Questionnaire#Item"; } }
             
             /// <summary>
             /// Unique id for item in questionnaire
@@ -664,11 +664,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Questionnaire#Questionnaire.item.enableWhen", IsNestedType=true)]
+        [FhirType("Questionnaire#EnableWhen", IsNestedType=true)]
         [DataContract]
         public partial class EnableWhenComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "EnableWhenComponent"; } }
+            public override string TypeName { get { return "Questionnaire#EnableWhen"; } }
             
             /// <summary>
             /// Question that determines whether item is enabled
@@ -822,11 +822,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Questionnaire#Questionnaire.item.option", IsNestedType=true)]
+        [FhirType("Questionnaire#Option", IsNestedType=true)]
         [DataContract]
         public partial class OptionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OptionComponent"; } }
+            public override string TypeName { get { return "Questionnaire#Option"; } }
             
             /// <summary>
             /// Answer value

--- a/src/Hl7.Fhir.Core/Model/Generated/QuestionnaireResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/QuestionnaireResponse.cs
@@ -91,11 +91,11 @@ namespace Hl7.Fhir.Model
             Stopped,
         }
 
-        [FhirType("QuestionnaireResponse#QuestionnaireResponse.item", IsNestedType=true)]
+        [FhirType("QuestionnaireResponse#Item", IsNestedType=true)]
         [DataContract]
         public partial class ItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ItemComponent"; } }
+            public override string TypeName { get { return "QuestionnaireResponse#Item"; } }
             
             /// <summary>
             /// Pointer to specific item from Questionnaire
@@ -323,11 +323,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("QuestionnaireResponse#QuestionnaireResponse.item.answer", IsNestedType=true)]
+        [FhirType("QuestionnaireResponse#Answer", IsNestedType=true)]
         [DataContract]
         public partial class AnswerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AnswerComponent"; } }
+            public override string TypeName { get { return "QuestionnaireResponse#Answer"; } }
             
             /// <summary>
             /// Single-valued answer to the question

--- a/src/Hl7.Fhir.Core/Model/Generated/ReferralRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ReferralRequest.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ReferralRequest"; } }
         
-        [FhirType("ReferralRequest#ReferralRequest.requester", IsNestedType=true)]
+        [FhirType("ReferralRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "ReferralRequest#Requester"; } }
             
             /// <summary>
             /// Individual making the request

--- a/src/Hl7.Fhir.Core/Model/Generated/RequestGroup.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/RequestGroup.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "RequestGroup"; } }
         
-        [FhirType("RequestGroup#RequestGroup.action", IsNestedType=true)]
+        [FhirType("RequestGroup#Action", IsNestedType=true)]
         [DataContract]
         public partial class ActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionComponent"; } }
+            public override string TypeName { get { return "RequestGroup#Action"; } }
             
             /// <summary>
             /// User-visible label for the action (e.g. 1. or A.)
@@ -615,11 +615,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("RequestGroup#RequestGroup.action.condition", IsNestedType=true)]
+        [FhirType("RequestGroup#Condition", IsNestedType=true)]
         [DataContract]
         public partial class ConditionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConditionComponent"; } }
+            public override string TypeName { get { return "RequestGroup#Condition"; } }
             
             /// <summary>
             /// applicability | start | stop
@@ -825,11 +825,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("RequestGroup#RequestGroup.action.relatedAction", IsNestedType=true)]
+        [FhirType("RequestGroup#RelatedAction", IsNestedType=true)]
         [DataContract]
         public partial class RelatedActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RelatedActionComponent"; } }
+            public override string TypeName { get { return "RequestGroup#RelatedAction"; } }
             
             /// <summary>
             /// What action this is related to

--- a/src/Hl7.Fhir.Core/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ResearchStudy.cs
@@ -97,11 +97,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("ResearchStudy#ResearchStudy.arm", IsNestedType=true)]
+        [FhirType("ResearchStudy#Arm", IsNestedType=true)]
         [DataContract]
         public partial class ArmComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ArmComponent"; } }
+            public override string TypeName { get { return "ResearchStudy#Arm"; } }
             
             /// <summary>
             /// Label for study arm

--- a/src/Hl7.Fhir.Core/Model/Generated/RiskAssessment.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/RiskAssessment.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "RiskAssessment"; } }
         
-        [FhirType("RiskAssessment#RiskAssessment.prediction", IsNestedType=true)]
+        [FhirType("RiskAssessment#Prediction", IsNestedType=true)]
         [DataContract]
         public partial class PredictionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "PredictionComponent"; } }
+            public override string TypeName { get { return "RiskAssessment#Prediction"; } }
             
             /// <summary>
             /// Possible outcome for the subject

--- a/src/Hl7.Fhir.Core/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SearchParameter.cs
@@ -223,11 +223,11 @@ namespace Hl7.Fhir.Model
             Type,
         }
 
-        [FhirType("SearchParameter#SearchParameter.component", IsNestedType=true)]
+        [FhirType("SearchParameter#Component", IsNestedType=true)]
         [DataContract]
         public partial class ComponentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ComponentComponent"; } }
+            public override string TypeName { get { return "SearchParameter#Component"; } }
             
             /// <summary>
             /// Defines how the part works

--- a/src/Hl7.Fhir.Core/Model/Generated/Sequence.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Sequence.cs
@@ -118,11 +118,11 @@ namespace Hl7.Fhir.Model
             Other,
         }
 
-        [FhirType("Sequence#Sequence.referenceSeq", IsNestedType=true)]
+        [FhirType("Sequence#ReferenceSeq", IsNestedType=true)]
         [DataContract]
         public partial class ReferenceSeqComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ReferenceSeqComponent"; } }
+            public override string TypeName { get { return "Sequence#ReferenceSeq"; } }
             
             /// <summary>
             /// Chromosome containing genetic finding
@@ -421,11 +421,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Sequence#Sequence.variant", IsNestedType=true)]
+        [FhirType("Sequence#Variant", IsNestedType=true)]
         [DataContract]
         public partial class VariantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "VariantComponent"; } }
+            public override string TypeName { get { return "Sequence#Variant"; } }
             
             /// <summary>
             /// Start position of the variant on the  reference sequence
@@ -686,11 +686,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Sequence#Sequence.quality", IsNestedType=true)]
+        [FhirType("Sequence#Quality", IsNestedType=true)]
         [DataContract]
         public partial class QualityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "QualityComponent"; } }
+            public override string TypeName { get { return "Sequence#Quality"; } }
             
             /// <summary>
             /// indel | snp | unknown
@@ -1202,11 +1202,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Sequence#Sequence.repository", IsNestedType=true)]
+        [FhirType("Sequence#Repository", IsNestedType=true)]
         [DataContract]
         public partial class RepositoryComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RepositoryComponent"; } }
+            public override string TypeName { get { return "Sequence#Repository"; } }
             
             /// <summary>
             /// directlink | openapi | login | oauth | other

--- a/src/Hl7.Fhir.Core/Model/Generated/Specimen.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Specimen.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Specimen#Specimen.collection", IsNestedType=true)]
+        [FhirType("Specimen#Collection", IsNestedType=true)]
         [DataContract]
         public partial class CollectionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CollectionComponent"; } }
+            public override string TypeName { get { return "Specimen#Collection"; } }
             
             /// <summary>
             /// Who collected the specimen
@@ -244,11 +244,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Specimen#Specimen.processing", IsNestedType=true)]
+        [FhirType("Specimen#Processing", IsNestedType=true)]
         [DataContract]
         public partial class ProcessingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ProcessingComponent"; } }
+            public override string TypeName { get { return "Specimen#Processing"; } }
             
             /// <summary>
             /// Textual description of procedure
@@ -404,11 +404,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Specimen#Specimen.container", IsNestedType=true)]
+        [FhirType("Specimen#Container", IsNestedType=true)]
         [DataContract]
         public partial class ContainerComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContainerComponent"; } }
+            public override string TypeName { get { return "Specimen#Container"; } }
             
             /// <summary>
             /// Id for the container

--- a/src/Hl7.Fhir.Core/Model/Generated/StructureDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/StructureDefinition.cs
@@ -133,11 +133,11 @@ namespace Hl7.Fhir.Model
             Constraint,
         }
 
-        [FhirType("StructureDefinition#StructureDefinition.mapping", IsNestedType=true)]
+        [FhirType("StructureDefinition#Mapping", IsNestedType=true)]
         [DataContract]
         public partial class MappingComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MappingComponent"; } }
+            public override string TypeName { get { return "StructureDefinition#Mapping"; } }
             
             /// <summary>
             /// Internal id when this mapping is used
@@ -343,11 +343,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureDefinition#StructureDefinition.snapshot", IsNestedType=true)]
+        [FhirType("StructureDefinition#Snapshot", IsNestedType=true)]
         [DataContract]
         public partial class SnapshotComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SnapshotComponent"; } }
+            public override string TypeName { get { return "StructureDefinition#Snapshot"; } }
             
             /// <summary>
             /// Definition of elements in the resource (if no StructureDefinition)
@@ -427,11 +427,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureDefinition#StructureDefinition.differential", IsNestedType=true)]
+        [FhirType("StructureDefinition#Differential", IsNestedType=true)]
         [DataContract]
         public partial class DifferentialComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DifferentialComponent"; } }
+            public override string TypeName { get { return "StructureDefinition#Differential"; } }
             
             /// <summary>
             /// Definition of elements in the resource (if no StructureDefinition)

--- a/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
@@ -337,11 +337,11 @@ namespace Hl7.Fhir.Model
             Cp,
         }
 
-        [FhirType("StructureMap#StructureMap.structure", IsNestedType=true)]
+        [FhirType("StructureMap#Structure", IsNestedType=true)]
         [DataContract]
         public partial class StructureComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "StructureComponent"; } }
+            public override string TypeName { get { return "StructureMap#Structure"; } }
             
             /// <summary>
             /// Canonical URL for structure definition
@@ -548,11 +548,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group", IsNestedType=true)]
+        [FhirType("StructureMap#Group", IsNestedType=true)]
         [DataContract]
         public partial class GroupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "GroupComponent"; } }
+            public override string TypeName { get { return "StructureMap#Group"; } }
             
             /// <summary>
             /// Human-readable label
@@ -797,11 +797,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.input", IsNestedType=true)]
+        [FhirType("StructureMap#Input", IsNestedType=true)]
         [DataContract]
         public partial class InputComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InputComponent"; } }
+            public override string TypeName { get { return "StructureMap#Input"; } }
             
             /// <summary>
             /// Name for this instance of data
@@ -1008,11 +1008,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.rule", IsNestedType=true)]
+        [FhirType("StructureMap#Rule", IsNestedType=true)]
         [DataContract]
         public partial class RuleComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RuleComponent"; } }
+            public override string TypeName { get { return "StructureMap#Rule"; } }
             
             /// <summary>
             /// Name of the rule for internal references
@@ -1222,11 +1222,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.rule.source", IsNestedType=true)]
+        [FhirType("StructureMap#Source", IsNestedType=true)]
         [DataContract]
         public partial class SourceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SourceComponent"; } }
+            public override string TypeName { get { return "StructureMap#Source"; } }
             
             /// <summary>
             /// Type or variable this rule applies to
@@ -1632,11 +1632,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.rule.target", IsNestedType=true)]
+        [FhirType("StructureMap#Target", IsNestedType=true)]
         [DataContract]
         public partial class TargetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TargetComponent"; } }
+            public override string TypeName { get { return "StructureMap#Target"; } }
             
             /// <summary>
             /// Type or variable this rule applies to
@@ -1969,11 +1969,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.rule.target.parameter", IsNestedType=true)]
+        [FhirType("StructureMap#Parameter", IsNestedType=true)]
         [DataContract]
         public partial class ParameterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParameterComponent"; } }
+            public override string TypeName { get { return "StructureMap#Parameter"; } }
             
             /// <summary>
             /// Parameter value - variable or literal
@@ -2055,11 +2055,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("StructureMap#StructureMap.group.rule.dependent", IsNestedType=true)]
+        [FhirType("StructureMap#Dependent", IsNestedType=true)]
         [DataContract]
         public partial class DependentComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DependentComponent"; } }
+            public override string TypeName { get { return "StructureMap#Dependent"; } }
             
             /// <summary>
             /// Name of a rule or group to apply

--- a/src/Hl7.Fhir.Core/Model/Generated/Subscription.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Subscription.cs
@@ -124,11 +124,11 @@ namespace Hl7.Fhir.Model
             Message,
         }
 
-        [FhirType("Subscription#Subscription.channel", IsNestedType=true)]
+        [FhirType("Subscription#Channel", IsNestedType=true)]
         [DataContract]
         public partial class ChannelComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ChannelComponent"; } }
+            public override string TypeName { get { return "Subscription#Channel"; } }
             
             /// <summary>
             /// rest-hook | websocket | email | sms | message

--- a/src/Hl7.Fhir.Core/Model/Generated/Substance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Substance.cs
@@ -79,11 +79,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Substance#Substance.instance", IsNestedType=true)]
+        [FhirType("Substance#Instance", IsNestedType=true)]
         [DataContract]
         public partial class InstanceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "InstanceComponent"; } }
+            public override string TypeName { get { return "Substance#Instance"; } }
             
             /// <summary>
             /// Identifier of the package/container
@@ -216,11 +216,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Substance#Substance.ingredient", IsNestedType=true)]
+        [FhirType("Substance#Ingredient", IsNestedType=true)]
         [DataContract]
         public partial class IngredientComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "IngredientComponent"; } }
+            public override string TypeName { get { return "Substance#Ingredient"; } }
             
             /// <summary>
             /// Optional amount (concentration)

--- a/src/Hl7.Fhir.Core/Model/Generated/SupplyDelivery.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SupplyDelivery.cs
@@ -85,11 +85,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("SupplyDelivery#SupplyDelivery.suppliedItem", IsNestedType=true)]
+        [FhirType("SupplyDelivery#SuppliedItem", IsNestedType=true)]
         [DataContract]
         public partial class SuppliedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SuppliedItemComponent"; } }
+            public override string TypeName { get { return "SupplyDelivery#SuppliedItem"; } }
             
             /// <summary>
             /// Amount dispensed

--- a/src/Hl7.Fhir.Core/Model/Generated/SupplyRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SupplyRequest.cs
@@ -103,11 +103,11 @@ namespace Hl7.Fhir.Model
             Unknown,
         }
 
-        [FhirType("SupplyRequest#SupplyRequest.orderedItem", IsNestedType=true)]
+        [FhirType("SupplyRequest#OrderedItem", IsNestedType=true)]
         [DataContract]
         public partial class OrderedItemComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OrderedItemComponent"; } }
+            public override string TypeName { get { return "SupplyRequest#OrderedItem"; } }
             
             /// <summary>
             /// The requested amount of the item indicated
@@ -207,11 +207,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("SupplyRequest#SupplyRequest.requester", IsNestedType=true)]
+        [FhirType("SupplyRequest#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "SupplyRequest#Requester"; } }
             
             /// <summary>
             /// Individual making the request

--- a/src/Hl7.Fhir.Core/Model/Generated/Task.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Task.cs
@@ -133,11 +133,11 @@ namespace Hl7.Fhir.Model
             EnteredInError,
         }
 
-        [FhirType("Task#Task.requester", IsNestedType=true)]
+        [FhirType("Task#Requester", IsNestedType=true)]
         [DataContract]
         public partial class RequesterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequesterComponent"; } }
+            public override string TypeName { get { return "Task#Requester"; } }
             
             /// <summary>
             /// Individual asking for task
@@ -239,11 +239,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Task#Task.restriction", IsNestedType=true)]
+        [FhirType("Task#Restriction", IsNestedType=true)]
         [DataContract]
         public partial class RestrictionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RestrictionComponent"; } }
+            public override string TypeName { get { return "Task#Restriction"; } }
             
             /// <summary>
             /// How many times to repeat
@@ -379,11 +379,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Task#Task.input", IsNestedType=true)]
+        [FhirType("Task#Parameter", IsNestedType=true)]
         [DataContract]
         public partial class ParameterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParameterComponent"; } }
+            public override string TypeName { get { return "Task#Parameter"; } }
             
             /// <summary>
             /// Label for the input
@@ -484,11 +484,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("Task#Task.output", IsNestedType=true)]
+        [FhirType("Task#Output", IsNestedType=true)]
         [DataContract]
         public partial class OutputComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OutputComponent"; } }
+            public override string TypeName { get { return "Task#Output"; } }
             
             /// <summary>
             /// Label for output

--- a/src/Hl7.Fhir.Core/Model/Generated/Template-DataTypeModel.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Template-DataTypeModel.cs
@@ -1,7 +1,7 @@
 
 
 //
-// Model Generated on Mon, 20 Apr 2020 12:22:40 GMT for FHIR v3.0.2
+// Model Generated on Fri, 08 May 2020 16:21:05 GMT for FHIR v3.0.2
 //
 // Generated Shared Enumeration: ResourceType
 
@@ -72,7 +72,6 @@
 // Generated items
 // Hl7.Fhir.Core\Model\Generated\UsageContext.cs
 // Hl7.Fhir.Core\Model\Generated\TriggerDefinition.cs
-// Hl7.Fhir.Core\Model\Generated\Timing.cs
 // Hl7.Fhir.Core\Model\Generated\Signature.cs
 // Hl7.Fhir.Core\Model\Generated\SampledData.cs
 // Hl7.Fhir.Core\Model\Generated\RelatedArtifact.cs
@@ -94,8 +93,3 @@
 // Hl7.Fhir.Core\Model\Generated\Attachment.cs
 // Hl7.Fhir.Core\Model\Generated\Annotation.cs
 // Hl7.Fhir.Core\Model\Generated\Address.cs
-// Hl7.Fhir.Core\Model\Generated\UnsignedInt.cs
-// Hl7.Fhir.Core\Model\Generated\Time.cs
-// Hl7.Fhir.Core\Model\Generated\PositiveInt.cs
-// Hl7.Fhir.Core\Model\Generated\Markdown.cs
-// Hl7.Fhir.Core\Model\Generated\FhirDecimal.cs

--- a/src/Hl7.Fhir.Core/Model/Generated/Template-DataTypeModel.tt
+++ b/src/Hl7.Fhir.Core/Model/Generated/Template-DataTypeModel.tt
@@ -160,7 +160,8 @@
 				resourceDescription = (e as System.Xml.XmlElement).SelectSingleNode("fhir:differential/fhir:element[fhir:path/@value='"+rawResourceName+"']/fhir:short/@value", nsR).Value;
 	
 	        var skippedTypes = new[] { "Narrative", "Extension", "Code", "Coding", "Date", "FhirBoolean", "Base64Binary",
-				"FhirDateTime", "FhirString", "FhirUri", "Id", "Instant", "Integer", "Meta", "Oid", "Uuid", "Xhtml","BackboneElement" };
+				"FhirDateTime", "FhirString", "FhirUri", "Id", "Instant", "Integer", "Meta", "Oid", "Uuid", "Xhtml",
+				"BackboneElement", "FhirDecimal", "Markdown", "PositiveInt", "Time", "Timing", "UnsignedInt" };
 			
 			if (skippedTypes.Contains(resourceName)) continue;
 			manager.StartNewFile(resourceName + ".cs");
@@ -397,10 +398,12 @@ if (!abstractType){
 		System.Xml.XmlAttribute componentElement = e2.SelectSingleNode("fhir:path/@value", nsR) as System.Xml.XmlAttribute;
 		string v = componentElement.Value;
 		string definingPath = componentElement.Value;
+		string fhirBackboneType;
 		if (v.Contains("."))
         {
 			int index = v.LastIndexOf(".");
 			v = v.Substring(index+1, 1).ToUpper() + v.Substring(index+2);
+			fhirBackboneType = v;
         }
 		else
 		{
@@ -411,8 +414,10 @@ if (!abstractType){
 		if (componentNameElement != null)
         {
 			componentName = componentNameElement.Value + "Component";
+			fhirBackboneType = componentName;
         }
 
+		string fhirTypeName = resourceName + '#' + fhirBackboneType;
 		List<PropertyDetails> component = new List<PropertyDetails>();
 		foreach (System.Xml.XmlElement snapshotElement in (e as System.Xml.XmlElement).SelectNodes("fhir:differential/fhir:element", nsR))
         {
@@ -421,11 +426,11 @@ if (!abstractType){
 				component.Add(pd);
         }
 #>
-        [FhirType("<#= resourceName + '#' + definingPath #>", IsNestedType=true)]
+        [FhirType("<#= fhirTypeName #>", IsNestedType=true)]
         [DataContract]
         public partial class <#= componentName #> : Hl7.Fhir.Model.Element
         {
-            public override string TypeName { get { return "<#= componentName #>"; } }
+            public override string TypeName { get { return "<#= fhirTypeName #>"; } }
             
 <#
 	int nComponentPropNum = 30;

--- a/src/Hl7.Fhir.Core/Model/Generated/Template-Model.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Template-Model.cs
@@ -2,7 +2,7 @@
 
 
 //
-// Model Generated on Mon, 20 Apr 2020 21:03:11 GMT for FHIR v3.0.2
+// Model Generated on Fri, 08 May 2020 16:06:17 GMT for FHIR v3.0.2
 //
 // Generated Shared Enumeration: ResourceType
 	// Used in model class (resource): ActivityDefinition.kind

--- a/src/Hl7.Fhir.Core/Model/Generated/Template-Model.tt
+++ b/src/Hl7.Fhir.Core/Model/Generated/Template-Model.tt
@@ -272,20 +272,29 @@ if(true) {
 	foreach (System.Xml.XmlElement e2 in (e as System.Xml.XmlElement).SelectNodes("fhir:differential/fhir:element[fhir:type/fhir:code/@value = 'BackboneElement']", nsR))
     {
 		System.Xml.XmlAttribute componentElement = e2.SelectSingleNode("fhir:path/@value", nsR) as System.Xml.XmlAttribute;
-		string v = componentElement.Value;
-		string definingPath = componentElement.Value;
-
-		if (v.Contains("."))
-        {
-			int index = v.LastIndexOf(".");
-			v = v.Substring(index+1, 1).ToUpper() + v.Substring(index+2);
-        }
-		string componentName = v + "Component";
 		System.Xml.XmlAttribute componentNameElement = (System.Xml.XmlAttribute)e2.SelectSingleNode("fhir:extension[@url = 'http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name']/fhir:valueString/@value", nsR);
+
+		string componentStartName;
+
 		if (componentNameElement != null)
         {
-			componentName = componentNameElement.Value + "Component";
+			componentStartName = componentNameElement.Value;		
         }
+		else
+		{
+			componentStartName = componentElement.Value;
+
+			if(componentStartName.Contains("."))
+			{
+				int index = componentStartName.LastIndexOf(".");
+		        componentStartName = componentStartName.Substring(index+1,1).ToUpper() + componentStartName.Substring(index+2);
+			}
+			
+		//	WriteLine("Encountered a nested component without a name at " + componentElement.Value);
+		}
+
+		string fhirTypeName = resourceName + "#" + componentStartName;
+		string componentName = componentStartName + "Component";
 
 		List<PropertyDetails> component = new List<PropertyDetails>();
 		foreach (System.Xml.XmlElement snapshotElement in (e as System.Xml.XmlElement).SelectNodes("fhir:differential/fhir:element", nsR))
@@ -295,11 +304,11 @@ if(true) {
 				component.Add(pd);
         }
 #>
-        [FhirType("<#= resourceName + '#' + definingPath #>", IsNestedType=true)]
+        [FhirType("<#= fhirTypeName #>", IsNestedType=true)]
         [DataContract]
         public partial class <#= componentName #> : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "<#= componentName #>"; } }
+            public override string TypeName { get { return "<#= fhirTypeName #>"; } }
             
 <#
 	int nComponentPropNum = 30;

--- a/src/Hl7.Fhir.Core/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/TestReport.cs
@@ -184,11 +184,11 @@ namespace Hl7.Fhir.Model
             Error,
         }
 
-        [FhirType("TestReport#TestReport.participant", IsNestedType=true)]
+        [FhirType("TestReport#Participant", IsNestedType=true)]
         [DataContract]
         public partial class ParticipantComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParticipantComponent"; } }
+            public override string TypeName { get { return "TestReport#Participant"; } }
             
             /// <summary>
             /// test-engine | client | server
@@ -359,11 +359,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.setup", IsNestedType=true)]
+        [FhirType("TestReport#Setup", IsNestedType=true)]
         [DataContract]
         public partial class SetupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SetupComponent"; } }
+            public override string TypeName { get { return "TestReport#Setup"; } }
             
             /// <summary>
             /// A setup operation or assert that was executed
@@ -443,11 +443,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.setup.action", IsNestedType=true)]
+        [FhirType("TestReport#SetupAction", IsNestedType=true)]
         [DataContract]
         public partial class SetupActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SetupActionComponent"; } }
+            public override string TypeName { get { return "TestReport#SetupAction"; } }
             
             /// <summary>
             /// The operation to perform
@@ -544,11 +544,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.setup.action.operation", IsNestedType=true)]
+        [FhirType("TestReport#Operation", IsNestedType=true)]
         [DataContract]
         public partial class OperationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OperationComponent"; } }
+            public override string TypeName { get { return "TestReport#Operation"; } }
             
             /// <summary>
             /// pass | skip | fail | warning | error
@@ -700,11 +700,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.setup.action.assert", IsNestedType=true)]
+        [FhirType("TestReport#Assert", IsNestedType=true)]
         [DataContract]
         public partial class AssertComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AssertComponent"; } }
+            public override string TypeName { get { return "TestReport#Assert"; } }
             
             /// <summary>
             /// pass | skip | fail | warning | error
@@ -856,11 +856,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.test", IsNestedType=true)]
+        [FhirType("TestReport#Test", IsNestedType=true)]
         [DataContract]
         public partial class TestComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TestComponent"; } }
+            public override string TypeName { get { return "TestReport#Test"; } }
             
             /// <summary>
             /// Tracking/logging name of this test
@@ -1012,11 +1012,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.test.action", IsNestedType=true)]
+        [FhirType("TestReport#TestAction", IsNestedType=true)]
         [DataContract]
         public partial class TestActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TestActionComponent"; } }
+            public override string TypeName { get { return "TestReport#TestAction"; } }
             
             /// <summary>
             /// The operation performed
@@ -1113,11 +1113,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.teardown", IsNestedType=true)]
+        [FhirType("TestReport#Teardown", IsNestedType=true)]
         [DataContract]
         public partial class TeardownComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TeardownComponent"; } }
+            public override string TypeName { get { return "TestReport#Teardown"; } }
             
             /// <summary>
             /// One or more teardown operations performed
@@ -1197,11 +1197,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestReport#TestReport.teardown.action", IsNestedType=true)]
+        [FhirType("TestReport#TeardownAction", IsNestedType=true)]
         [DataContract]
         public partial class TeardownActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TeardownActionComponent"; } }
+            public override string TypeName { get { return "TestReport#TeardownAction"; } }
             
             /// <summary>
             /// The teardown operation performed

--- a/src/Hl7.Fhir.Core/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/TestScript.cs
@@ -1354,11 +1354,11 @@ namespace Hl7.Fhir.Model
             Unprocessable,
         }
 
-        [FhirType("TestScript#TestScript.origin", IsNestedType=true)]
+        [FhirType("TestScript#Origin", IsNestedType=true)]
         [DataContract]
         public partial class OriginComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OriginComponent"; } }
+            public override string TypeName { get { return "TestScript#Origin"; } }
             
             /// <summary>
             /// The index of the abstract origin server starting at 1
@@ -1475,11 +1475,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.destination", IsNestedType=true)]
+        [FhirType("TestScript#Destination", IsNestedType=true)]
         [DataContract]
         public partial class DestinationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DestinationComponent"; } }
+            public override string TypeName { get { return "TestScript#Destination"; } }
             
             /// <summary>
             /// The index of the abstract destination server starting at 1
@@ -1596,11 +1596,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.metadata", IsNestedType=true)]
+        [FhirType("TestScript#Metadata", IsNestedType=true)]
         [DataContract]
         public partial class MetadataComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "MetadataComponent"; } }
+            public override string TypeName { get { return "TestScript#Metadata"; } }
             
             /// <summary>
             /// Links to the FHIR specification
@@ -1699,11 +1699,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.metadata.link", IsNestedType=true)]
+        [FhirType("TestScript#Link", IsNestedType=true)]
         [DataContract]
         public partial class LinkComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "LinkComponent"; } }
+            public override string TypeName { get { return "TestScript#Link"; } }
             
             /// <summary>
             /// URL to the specification
@@ -1837,11 +1837,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.metadata.capability", IsNestedType=true)]
+        [FhirType("TestScript#Capability", IsNestedType=true)]
         [DataContract]
         public partial class CapabilityComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "CapabilityComponent"; } }
+            public override string TypeName { get { return "TestScript#Capability"; } }
             
             /// <summary>
             /// Are the capabilities required?
@@ -2141,11 +2141,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.fixture", IsNestedType=true)]
+        [FhirType("TestScript#Fixture", IsNestedType=true)]
         [DataContract]
         public partial class FixtureComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FixtureComponent"; } }
+            public override string TypeName { get { return "TestScript#Fixture"; } }
             
             /// <summary>
             /// Whether or not to implicitly create the fixture during setup
@@ -2298,11 +2298,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.variable", IsNestedType=true)]
+        [FhirType("TestScript#Variable", IsNestedType=true)]
         [DataContract]
         public partial class VariableComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "VariableComponent"; } }
+            public override string TypeName { get { return "TestScript#Variable"; } }
             
             /// <summary>
             /// Descriptive name for this variable
@@ -2652,11 +2652,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.rule", IsNestedType=true)]
+        [FhirType("TestScript#Rule", IsNestedType=true)]
         [DataContract]
         public partial class RuleComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RuleComponent"; } }
+            public override string TypeName { get { return "TestScript#Rule"; } }
             
             /// <summary>
             /// Assert rule resource reference
@@ -2757,11 +2757,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.rule.param", IsNestedType=true)]
+        [FhirType("TestScript#RuleParam", IsNestedType=true)]
         [DataContract]
         public partial class RuleParamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RuleParamComponent"; } }
+            public override string TypeName { get { return "TestScript#RuleParam"; } }
             
             /// <summary>
             /// Parameter name matching external assert rule parameter
@@ -2895,11 +2895,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.ruleset", IsNestedType=true)]
+        [FhirType("TestScript#Ruleset", IsNestedType=true)]
         [DataContract]
         public partial class RulesetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RulesetComponent"; } }
+            public override string TypeName { get { return "TestScript#Ruleset"; } }
             
             /// <summary>
             /// Assert ruleset resource reference
@@ -3000,11 +3000,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.ruleset.rule", IsNestedType=true)]
+        [FhirType("TestScript#RulesetRule", IsNestedType=true)]
         [DataContract]
         public partial class RulesetRuleComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RulesetRuleComponent"; } }
+            public override string TypeName { get { return "TestScript#RulesetRule"; } }
             
             /// <summary>
             /// Id of referenced rule within the ruleset
@@ -3121,11 +3121,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.ruleset.rule.param", IsNestedType=true)]
+        [FhirType("TestScript#RulesetRuleParam", IsNestedType=true)]
         [DataContract]
         public partial class RulesetRuleParamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RulesetRuleParamComponent"; } }
+            public override string TypeName { get { return "TestScript#RulesetRuleParam"; } }
             
             /// <summary>
             /// Parameter name matching external assert ruleset rule parameter
@@ -3259,11 +3259,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup", IsNestedType=true)]
+        [FhirType("TestScript#Setup", IsNestedType=true)]
         [DataContract]
         public partial class SetupComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SetupComponent"; } }
+            public override string TypeName { get { return "TestScript#Setup"; } }
             
             /// <summary>
             /// A setup operation or assert to perform
@@ -3343,11 +3343,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action", IsNestedType=true)]
+        [FhirType("TestScript#SetupAction", IsNestedType=true)]
         [DataContract]
         public partial class SetupActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "SetupActionComponent"; } }
+            public override string TypeName { get { return "TestScript#SetupAction"; } }
             
             /// <summary>
             /// The setup operation to perform
@@ -3444,11 +3444,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.operation", IsNestedType=true)]
+        [FhirType("TestScript#Operation", IsNestedType=true)]
         [DataContract]
         public partial class OperationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "OperationComponent"; } }
+            public override string TypeName { get { return "TestScript#Operation"; } }
             
             /// <summary>
             /// The operation code type that will be executed
@@ -4050,11 +4050,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.operation.requestHeader", IsNestedType=true)]
+        [FhirType("TestScript#RequestHeader", IsNestedType=true)]
         [DataContract]
         public partial class RequestHeaderComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "RequestHeaderComponent"; } }
+            public override string TypeName { get { return "TestScript#RequestHeader"; } }
             
             /// <summary>
             /// HTTP header field name
@@ -4189,11 +4189,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert", IsNestedType=true)]
+        [FhirType("TestScript#Assert", IsNestedType=true)]
         [DataContract]
         public partial class AssertComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "AssertComponent"; } }
+            public override string TypeName { get { return "TestScript#Assert"; } }
             
             /// <summary>
             /// Tracking/logging assertion label
@@ -5082,11 +5082,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert.rule", IsNestedType=true)]
+        [FhirType("TestScript#ActionAssertRule", IsNestedType=true)]
         [DataContract]
         public partial class ActionAssertRuleComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionAssertRuleComponent"; } }
+            public override string TypeName { get { return "TestScript#ActionAssertRule"; } }
             
             /// <summary>
             /// Id of the TestScript.rule
@@ -5203,11 +5203,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert.rule.param", IsNestedType=true)]
+        [FhirType("TestScript#ActionAssertRuleParam", IsNestedType=true)]
         [DataContract]
         public partial class ActionAssertRuleParamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionAssertRuleParamComponent"; } }
+            public override string TypeName { get { return "TestScript#ActionAssertRuleParam"; } }
             
             /// <summary>
             /// Parameter name matching external assert rule parameter
@@ -5342,11 +5342,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert.ruleset", IsNestedType=true)]
+        [FhirType("TestScript#ActionAssertRuleset", IsNestedType=true)]
         [DataContract]
         public partial class ActionAssertRulesetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionAssertRulesetComponent"; } }
+            public override string TypeName { get { return "TestScript#ActionAssertRuleset"; } }
             
             /// <summary>
             /// Id of the TestScript.ruleset
@@ -5463,11 +5463,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert.ruleset.rule", IsNestedType=true)]
+        [FhirType("TestScript#ActionAssertRulesetRule", IsNestedType=true)]
         [DataContract]
         public partial class ActionAssertRulesetRuleComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ActionAssertRulesetRuleComponent"; } }
+            public override string TypeName { get { return "TestScript#ActionAssertRulesetRule"; } }
             
             /// <summary>
             /// Id of referenced rule within the ruleset
@@ -5584,11 +5584,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.setup.action.assert.ruleset.rule.param", IsNestedType=true)]
+        [FhirType("TestScript#Param", IsNestedType=true)]
         [DataContract]
         public partial class ParamComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParamComponent"; } }
+            public override string TypeName { get { return "TestScript#Param"; } }
             
             /// <summary>
             /// Parameter name matching external assert ruleset rule parameter
@@ -5723,11 +5723,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.test", IsNestedType=true)]
+        [FhirType("TestScript#Test", IsNestedType=true)]
         [DataContract]
         public partial class TestComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TestComponent"; } }
+            public override string TypeName { get { return "TestScript#Test"; } }
             
             /// <summary>
             /// Tracking/logging name of this test
@@ -5879,11 +5879,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.test.action", IsNestedType=true)]
+        [FhirType("TestScript#TestAction", IsNestedType=true)]
         [DataContract]
         public partial class TestActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TestActionComponent"; } }
+            public override string TypeName { get { return "TestScript#TestAction"; } }
             
             /// <summary>
             /// The setup operation to perform
@@ -5980,11 +5980,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.teardown", IsNestedType=true)]
+        [FhirType("TestScript#Teardown", IsNestedType=true)]
         [DataContract]
         public partial class TeardownComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TeardownComponent"; } }
+            public override string TypeName { get { return "TestScript#Teardown"; } }
             
             /// <summary>
             /// One or more teardown operations to perform
@@ -6064,11 +6064,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("TestScript#TestScript.teardown.action", IsNestedType=true)]
+        [FhirType("TestScript#TeardownAction", IsNestedType=true)]
         [DataContract]
         public partial class TeardownActionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "TeardownActionComponent"; } }
+            public override string TypeName { get { return "TestScript#TeardownAction"; } }
             
             /// <summary>
             /// The teardown operation to perform

--- a/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
@@ -52,11 +52,11 @@ namespace Hl7.Fhir.Model
     {
         public override string TypeName { get { return "ValueSet"; } }
         
-        [FhirType("ValueSet#ValueSet.compose", IsNestedType=true)]
+        [FhirType("ValueSet#Compose", IsNestedType=true)]
         [DataContract]
         public partial class ComposeComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ComposeComponent"; } }
+            public override string TypeName { get { return "ValueSet#Compose"; } }
             
             /// <summary>
             /// Fixed date for version-less references (transitive)
@@ -227,11 +227,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.compose.include", IsNestedType=true)]
+        [FhirType("ValueSet#ConceptSet", IsNestedType=true)]
         [DataContract]
         public partial class ConceptSetComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConceptSetComponent"; } }
+            public override string TypeName { get { return "ValueSet#ConceptSet"; } }
             
             /// <summary>
             /// The system the codes come from
@@ -439,11 +439,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.compose.include.concept", IsNestedType=true)]
+        [FhirType("ValueSet#ConceptReference", IsNestedType=true)]
         [DataContract]
         public partial class ConceptReferenceComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ConceptReferenceComponent"; } }
+            public override string TypeName { get { return "ValueSet#ConceptReference"; } }
             
             /// <summary>
             /// Code or expression from system
@@ -596,11 +596,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.compose.include.concept.designation", IsNestedType=true)]
+        [FhirType("ValueSet#Designation", IsNestedType=true)]
         [DataContract]
         public partial class DesignationComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DesignationComponent"; } }
+            public override string TypeName { get { return "ValueSet#Designation"; } }
             
             /// <summary>
             /// Human language of the designation
@@ -752,11 +752,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.compose.include.filter", IsNestedType=true)]
+        [FhirType("ValueSet#Filter", IsNestedType=true)]
         [DataContract]
         public partial class FilterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "FilterComponent"; } }
+            public override string TypeName { get { return "ValueSet#Filter"; } }
             
             /// <summary>
             /// A property defined by the code system
@@ -928,11 +928,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.expansion", IsNestedType=true)]
+        [FhirType("ValueSet#Expansion", IsNestedType=true)]
         [DataContract]
         public partial class ExpansionComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ExpansionComponent"; } }
+            public override string TypeName { get { return "ValueSet#Expansion"; } }
             
             /// <summary>
             /// Uniquely identifies this expansion
@@ -1177,11 +1177,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.expansion.parameter", IsNestedType=true)]
+        [FhirType("ValueSet#Parameter", IsNestedType=true)]
         [DataContract]
         public partial class ParameterComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ParameterComponent"; } }
+            public override string TypeName { get { return "ValueSet#Parameter"; } }
             
             /// <summary>
             /// Name as assigned by the server
@@ -1299,11 +1299,11 @@ namespace Hl7.Fhir.Model
         }
         
         
-        [FhirType("ValueSet#ValueSet.expansion.contains", IsNestedType=true)]
+        [FhirType("ValueSet#Contains", IsNestedType=true)]
         [DataContract]
         public partial class ContainsComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "ContainsComponent"; } }
+            public override string TypeName { get { return "ValueSet#Contains"; } }
             
             /// <summary>
             /// System value for the code

--- a/src/Hl7.Fhir.Core/Model/Generated/VisionPrescription.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/VisionPrescription.cs
@@ -106,11 +106,11 @@ namespace Hl7.Fhir.Model
             Out,
         }
 
-        [FhirType("VisionPrescription#VisionPrescription.dispense", IsNestedType=true)]
+        [FhirType("VisionPrescription#Dispense", IsNestedType=true)]
         [DataContract]
         public partial class DispenseComponent : Hl7.Fhir.Model.BackboneElement
         {
-            public override string TypeName { get { return "DispenseComponent"; } }
+            public override string TypeName { get { return "VisionPrescription#Dispense"; } }
             
             /// <summary>
             /// Product to be supplied


### PR DESCRIPTION
Since R3 quite a few backbones carry an explicit name, given in the "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name" extension. Use this name for these types, including in the generated TypeName property.