### PR TITLE
Add configure await & temp fix provider (for R3)

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Specification
 
         public async T.Task<StructureDefinitionWalker> FromCanonicalAsync(string canonical)
         {
-            var sd = await AsyncResolver.FindStructureDefinitionAsync(canonical);
+            var sd = await AsyncResolver.FindStructureDefinitionAsync(canonical).ConfigureAwait(false);
             if (sd == null)
                 throw new StructureDefinitionWalkerException($"Cannot walk into unknown StructureDefinition with canonical '{canonical}' at '{Current.CanonicalPath()}'");
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
@@ -35,8 +35,8 @@ namespace Hl7.Fhir.Specification.Snapshot
             var nav = new ElementDefinitionNavigator(elements);
             if (nav.MoveToFirstChild() && !string.IsNullOrEmpty(baseProfileUrl))
             {
-                var sd = await AsyncResolver.FindStructureDefinitionAsync(baseProfileUrl);
-                if (await ensureSnapshot(sd, baseProfileUrl))
+                var sd = await AsyncResolver.FindStructureDefinitionAsync(baseProfileUrl).ConfigureAwait(false);
+                if (await ensureSnapshot(sd, baseProfileUrl).ConfigureAwait(false))
                 {
                     var baseNav = new ElementDefinitionNavigator(sd);
                     if (baseNav.MoveToFirstChild())
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         {
                             do
                             {
-                                await ensureBaseComponents(nav, baseNav, force);
+                                await ensureBaseComponents(nav, baseNav, force).ConfigureAwait(false);
                             } while (nav.MoveToNext());
                         }
                     }
@@ -77,7 +77,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     do
                     {
-                        await ensureBaseComponents(nav, baseNav, force);
+                        await ensureBaseComponents(nav, baseNav, force).ConfigureAwait(false);
                     } while (nav.MoveToNext());
 
                     nav.ReturnToBookmark(navBm);
@@ -95,13 +95,13 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var baseUrl = baseNav.StructureDefinition.BaseDefinition;
                 if (baseUrl != null)
                 {
-                    var baseDef = await AsyncResolver.FindStructureDefinitionAsync(baseUrl);
-                    if (await ensureSnapshot(baseDef, baseUrl, elem.Path))
+                    var baseDef = await AsyncResolver.FindStructureDefinitionAsync(baseUrl).ConfigureAwait(false);
+                    if (await ensureSnapshot(baseDef, baseUrl, elem.Path).ConfigureAwait(false))
                     {
                         baseNav = new ElementDefinitionNavigator(baseDef);
                         if (baseNav.MoveToFirstChild())
                         {
-                            await ensureBaseComponents(nav, baseNav, force);
+                            await ensureBaseComponents(nav, baseNav, force).ConfigureAwait(false);
                             return;
                         }
                     }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -143,7 +143,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         {
             structure.Snapshot = new StructureDefinition.SnapshotComponent()
             {
-                Element = await GenerateAsync(structure)
+                Element = await GenerateAsync(structure).ConfigureAwait(false)
             };
             structure.Snapshot.SetCreatedBySnapshotGenerator();
 
@@ -178,7 +178,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             _stack.OnBeforeGenerateSnapshot(structure.Url);
             try
             {
-                result = await generate(structure);
+                result = await generate(structure).ConfigureAwait(false);
             }
             finally
             {
@@ -233,7 +233,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             _stack.OnStartRecursion();
             try
             {
-                await expandElement(nav);
+                await expandElement(nav).ConfigureAwait(false);
             }
             finally
             {
@@ -261,7 +261,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             _stack.OnStartRecursion();
             try
             {
-                return await expandElement(nav);
+                return await expandElement(nav).ConfigureAwait(false);
             }
             finally
             {
@@ -323,7 +323,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             // StructureDefinition.SnapshotComponent snapshot = null;
             if (structure.BaseDefinition != null)
             {
-                var baseStructure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition);
+                var baseStructure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition).ConfigureAwait(false);
 
                 // [WMR 20161208] Handle unresolved base profile
                 if (baseStructure == null)
@@ -335,7 +335,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // [WMR 20161208] Handle missing differential
                 var location = differential.Element.Count > 0 ? differential.Element[0].Path : null;
-                if (!await ensureSnapshot(baseStructure, structure.BaseDefinition, location))
+                if (!await ensureSnapshot(baseStructure, structure.BaseDefinition, location).ConfigureAwait(false))
                 {
                     // Fatal error...
                     return null;
@@ -400,7 +400,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Ensure that ElementDefinition.Base components in base StructureDef are propertly initialized
                 // [WMR 20170424] Inherit existing base components, generate if missing
-                await ensureBaseComponents(snapshot.Element, structure.BaseDefinition, false);
+                await ensureBaseComponents(snapshot.Element, structure.BaseDefinition, false).ConfigureAwait(false);
 
                 // [WMR 20170208] Moved to *AFTER* ensureBaseComponents - emits annotations...
                 // [WMR 20160915] Derived profiles should never inherit the ChangedByDiff extension from the base structure
@@ -442,7 +442,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             // Then snapshot root is already generated and annotated to differential.Element[0]
             //Debug.WriteLineIf(diffRoot.HasSnapshotElementAnnotation(), $"[{nameof(SnapshotGenerator)}.{nameof(generate)} (before merge)] diff root is annotated with cached snapshot root...");
             
-            await merge(nav, diff);
+            await merge(nav, diff).ConfigureAwait(false);
 
             result = nav.ToListOfElements();
 
@@ -524,7 +524,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Resolve contentReference from core resource/datatype definition
                 // Specified by StructureDefinition.type == root element name
 
-                var coreStructure = await getStructureForContentReference(nav, true);
+                var coreStructure = await getStructureForContentReference(nav, true).ConfigureAwait(false);
                 // getStructureForContentReference emits issue if profile cannot be resolved
                 if (coreStructure == null) { return false; }
 
@@ -575,8 +575,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                     // Different profiles for common base type => expand the common base type (w/o custom profile)
                     // var typeRef = new ElementDefinition.TypeRefComponent() { Code = distinctTypeCodes[0] };
                     var typeRef = new ElementDefinition.TypeRefComponent() { Code = distinctTypeCode };
-                    StructureDefinition typeStructure = await getStructureForTypeRef(defn, typeRef, true);
-                    return await expandElementType(nav, typeStructure);
+                    StructureDefinition typeStructure = await getStructureForTypeRef(defn, typeRef, true).ConfigureAwait(false);
+                    return await expandElementType(nav, typeStructure).ConfigureAwait(false);
                 }
                 // Alternatively, we could try to expand the most specific common base profile, e.g. (Backbone)Element
                 // TODO: Determine the intersection, i.e. the most specific common type that all types are derived from
@@ -594,9 +594,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             else // if (defn.Type.Count == 1)
             {
                 // [WMR 20160720] Handle custom type profiles (GForge #9791)
-                StructureDefinition typeStructure = await getStructureForElementType(defn, true);
+                StructureDefinition typeStructure = await getStructureForElementType(defn, true).ConfigureAwait(false);
 
-                return await expandElementType(nav, typeStructure);
+                return await expandElementType(nav, typeStructure).ConfigureAwait(false);
             }
 
             return true;
@@ -625,7 +625,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                     // [WMR 20170220] WRONG...?
                     // Must merge nav on top of typeNav, not the other way around...
-                    await mergeElement(nav, typeNav);
+                    await mergeElement(nav, typeNav).ConfigureAwait(false);
 
                     // 1. Fully expand the snapshot of the external type profile
                     // 2. Clone, rebase and copy children into referencing profile below the referencing parent element
@@ -680,18 +680,18 @@ namespace Hl7.Fhir.Specification.Snapshot
                     switch (match.Action)
                     {
                         case ElementMatcher.MatchAction.Merge:
-                            await mergeElement(snap, diff);
+                            await mergeElement(snap, diff).ConfigureAwait(false);
                             break;
                         case ElementMatcher.MatchAction.Add:
-                            await addSlice(snap, diff, match.SliceBase);
+                            await addSlice(snap, diff, match.SliceBase).ConfigureAwait(false);
                             break;
                         case ElementMatcher.MatchAction.Slice:
-                            await startSlice(snap, diff, match.SliceBase);
+                            await startSlice(snap, diff, match.SliceBase).ConfigureAwait(false);
                             break;
                         case ElementMatcher.MatchAction.New:
                             // No matching base element; this is a new element definition
                             // snap is positioned at the associated parent element
-                            await createNewElement(snap, diff);
+                            await createNewElement(snap, diff).ConfigureAwait(false);
                             break;
                         case ElementMatcher.MatchAction.Invalid:
                             // Collect issue and ignore invalid element
@@ -709,7 +709,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         // Create a new resource element without a base element definition (for core type & resource profiles)
         private async T.Task createNewElement(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff)
         {
-            var (baseElement,typeStructure) = await getBaseElementForElementType(diff.Current);
+            var (baseElement,typeStructure) = await getBaseElementForElementType(diff.Current).ConfigureAwait(false);
             
             if (baseElement != null)
             {
@@ -751,7 +751,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             OnConstraint(snap.Current);
 
             // Merge children
-            await mergeElement(snap, diff);
+            await mergeElement(snap, diff).ConfigureAwait(false);
         }
 
         // Recursively merge the currently selected element and (grand)children from differential into snapshot
@@ -805,7 +805,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // [WMR 20170714] Can safely skip this step for the root node
                 if (!isRoot)
                 {
-                    isMerged = await mergeTypeProfiles(snap, diff);
+                    isMerged = await mergeTypeProfiles(snap, diff).ConfigureAwait(false);
                 }
 
                 // Then merge diff constraints from profile
@@ -856,14 +856,14 @@ namespace Hl7.Fhir.Specification.Snapshot
                     //}
 
                     // [WMR 20170711] Explicitly re-generate element ids
-                    if (!await expandElement(snap))
+                    if (!await expandElement(snap).ConfigureAwait(false))
                     {
                         return;
                     }
                 }
 
                 // Now, recursively merge the children
-                await merge(snap, diff);
+                await merge(snap, diff).ConfigureAwait(false);
 
                 // [WMR 20160720] NEW
                 // generate [...]extension.url/fixedUri if missing
@@ -1001,10 +1001,10 @@ namespace Hl7.Fhir.Specification.Snapshot
                     primaryDiffTypeProfile = profileRef.CanonicalUrl;
                 }
 
-                typeStructure = await AsyncResolver.FindStructureDefinitionAsync(primaryDiffTypeProfile);
+                typeStructure = await AsyncResolver.FindStructureDefinitionAsync(primaryDiffTypeProfile).ConfigureAwait(false);
                 
                 if(_settings.GenerateSnapshotForExternalProfiles)
-                    await ensureSnapshot(typeStructure, primaryDiffTypeProfile);
+                    await ensureSnapshot(typeStructure, primaryDiffTypeProfile).ConfigureAwait(false);
 
                 // [WMR 20170224] Verify that the resolved StructureDefinition is compatible with the element type
                 // [WMR 20170823] WRONG! Base element may specify multiple type options
@@ -1027,7 +1027,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 else
                 {
                     // The element type profile constraint must match one of the base types
-                    var isCompatible = await snap.Current.Type.AnyAsync(async t => await isValidTypeProfile(AsyncResolver, t.Code, typeStructure));
+                    var isCompatible = await snap.Current.Type.AnyAsync(async t => await isValidTypeProfile(AsyncResolver, t.Code, typeStructure).ConfigureAwait(false)).ConfigureAwait(false);
                     if (!isCompatible)
                     {
                         addIssueInvalidProfileType(diff.Current, typeStructure);
@@ -1040,7 +1040,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         // Note: if the element is to be expanded, then always merge full snapshot of the external type profile (!)
                         if (mustExpandElement(diff))
                         {
-                            if (!await ensureSnapshot(typeStructure, primaryDiffTypeProfile, diffNode))
+                            if (!await ensureSnapshot(typeStructure, primaryDiffTypeProfile, diffNode).ConfigureAwait(false))
                             {
                                 return false;
                             }
@@ -1122,7 +1122,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             // i.e. any overriding diff constraints from base snapshot are reverted back to original Address constraints
                             // Gets even more complicated with higher order derived base/type profiles...
 
-                            await mergeElement(snap, typeNav);
+                            await mergeElement(snap, typeNav).ConfigureAwait(false);
 
                             // Now call prepareTypeProfileElements (below) to clear element IDs and notify event subscribers
                         }
@@ -1130,7 +1130,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         {
                             // Expand and merge (only!) the root element of the external type profile
                             // Note: full expansion may trigger recursion, e.g. Element.id => identifier => string => Element
-                            var typeRootElem = await getSnapshotRootElement(typeStructure, primaryDiffTypeProfile, diffNode);
+                            var typeRootElem = await getSnapshotRootElement(typeStructure, primaryDiffTypeProfile, diffNode).ConfigureAwait(false);
                             if (typeRootElem == null) { return false; }
 
                             // Rebase before merging
@@ -1522,7 +1522,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 else
                 {
                     // [WMR 20161222] Recursively merge diff constraints on slicing entry and child elements (if any)
-                    await mergeElement(snap, diff);
+                    await mergeElement(snap, diff).ConfigureAwait(false);
                 }
             }
         }
@@ -1626,7 +1626,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             OnConstraint(snap.Current);
 
             // Merge differential
-            await mergeElement(snap, diff);
+            await mergeElement(snap, diff).ConfigureAwait(false);
         }
 
         void addSliceBase(ElementDefinitionNavigator snap, ElementDefinitionNavigator diff, ElementDefinitionNavigator sliceBase)
@@ -1734,7 +1734,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             Debug.Assert(elementDef != null);
             // Debug.Assert(elementDef.Type.Count > 0);
             var primaryType = elementDef.PrimaryType(); // Ignore any other types
-            return primaryType != null ? await getStructureForTypeRef(elementDef, primaryType, ensureSnapshot) : null;
+            return primaryType != null ? await getStructureForTypeRef(elementDef, primaryType, ensureSnapshot).ConfigureAwait(false) : null;
         }
 
         // Resolve StructureDefinition for the specified typeRef component
@@ -1755,9 +1755,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             if (!string.IsNullOrEmpty(typeProfile)) // && !typeRef.IsReference()) // && _settings.MergeTypeProfiles
                 {
                 // Try to resolve the custom element type profile reference
-                baseStructure = await AsyncResolver.FindStructureDefinitionAsync(typeProfile);
+                baseStructure = await AsyncResolver.FindStructureDefinitionAsync(typeProfile).ConfigureAwait(false);
                 isValidProfile = ensureSnapshot
-                    ? await this.ensureSnapshot(baseStructure, typeProfile, location)
+                    ? await this.ensureSnapshot(baseStructure, typeProfile, location).ConfigureAwait(false)
                     : this.verifyStructure(baseStructure, typeProfile, location);
             }
 
@@ -1765,12 +1765,12 @@ namespace Hl7.Fhir.Specification.Snapshot
             var typeCodeElem = typeRef.CodeElement;
             if (!isValidProfile && typeCodeElem != null && typeCodeElem.ObjectValue is string typeName)
             {
-                baseStructure = await getStructureDefinitionForTypeCode(AsyncResolver, typeCodeElem);
+                baseStructure = await getStructureDefinitionForTypeCode(AsyncResolver, typeCodeElem).ConfigureAwait(false);
                 // [WMR 20160906] Check if element type equals path (e.g. Resource root element), prevent infinite recursion
                 _ = (IsEqualPath(typeName, location)) ||
                     (
                         ensureSnapshot
-                        ? await this.ensureSnapshot(baseStructure, typeName, location)
+                        ? await this.ensureSnapshot(baseStructure, typeName, location).ConfigureAwait(false)
                         : this.verifyStructure(baseStructure, typeName, location)
                     );
 
@@ -1789,7 +1789,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             var typeCode = typeCodeElement.Value;
             if (!string.IsNullOrEmpty(typeCode))
             {
-                sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeCode);
+                sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeCode).ConfigureAwait(false);
             }
             else
             {
@@ -1797,7 +1797,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var typeName = typeCodeElement.ObjectValue as string;
                 if (!string.IsNullOrEmpty(typeName))
                 {
-                    sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeName);
+                    sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeName).ConfigureAwait(false);
                 }
             }
             return sd;
@@ -1823,9 +1823,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             if (!string.IsNullOrEmpty(coreType))
             {
                 // Try to resolve the custom element type profile reference
-                var coreSd = await AsyncResolver.FindStructureDefinitionForCoreTypeAsync(coreType);
+                var coreSd = await AsyncResolver.FindStructureDefinitionForCoreTypeAsync(coreType).ConfigureAwait(false);
                 _ = ensureSnapshot
-                    ? await this.ensureSnapshot(coreSd, coreType, location)
+                    ? await this.ensureSnapshot(coreSd, coreType, location).ConfigureAwait(false)
                     : this.verifyStructure(coreSd, coreType, location);
                 return coreSd;
             }
@@ -1871,7 +1871,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                     sd.Snapshot = new StructureDefinition.SnapshotComponent()
                     {
-                        Element = await generate(sd)
+                        Element = await generate(sd).ConfigureAwait(false)
                     };
 
                     if (!sd.HasSnapshot)
@@ -1891,7 +1891,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 }
 
                 // Generating the element base components may also resolve StructureDefinitions and cause recursion!
-                await ensureSnapshotBaseComponents(sd);
+                await ensureSnapshotBaseComponents(sd).ConfigureAwait(false);
             }
             finally
             {
@@ -1912,16 +1912,16 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             // Debug.Assert(elementDef.Type.Count > 0);
             var primaryType = elementDef.PrimaryType(); // Ignore any other types
-            return primaryType != null ? await getBaseElementForTypeRef(elementDef, primaryType) : default;
+            return primaryType != null ? await getBaseElementForTypeRef(elementDef, primaryType).ConfigureAwait(false) : default;
         }
 
         // Resolve the base element definition for the specified element type = the snapshot root element of the associated type profile
         private async T.Task<(ElementDefinition, StructureDefinition typeProfile)> getBaseElementForTypeRef(ElementDefinition elementDef, ElementDefinition.TypeRefComponent typeRef)
         {
-            var typeProfile = await getStructureForTypeRef(elementDef, typeRef, false);
+            var typeProfile = await getStructureForTypeRef(elementDef, typeRef, false).ConfigureAwait(false);
             
             return typeProfile != null ? 
-                (await getSnapshotRootElement(typeProfile, typeProfile.Url, elementDef.Path),typeProfile) 
+                (await getSnapshotRootElement(typeProfile, typeProfile.Url, elementDef.Path).ConfigureAwait(false), typeProfile) 
                 : default;
         }
 
@@ -2018,9 +2018,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             // profile that is currently being fully expanded, i.e. the url is already on the main stack.
 
             // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)}] {nameof(profileUri)} = '{profileUri}' - recursively resolve root element definition from base profile '{baseProfileUri}' ...");
-            var sdBase = await AsyncResolver.FindStructureDefinitionAsync(baseProfileUri);
+            var sdBase = await AsyncResolver.FindStructureDefinitionAsync(baseProfileUri).ConfigureAwait(false);
             // [WMR 20180108] diffRoot may be null (sparse differential w/o root)
-            var baseRoot = await getSnapshotRootElement(sdBase, baseProfileUri, diffRoot?.Path); // Recursion!
+            var baseRoot = await getSnapshotRootElement(sdBase, baseProfileUri, diffRoot?.Path).ConfigureAwait(false); // Recursion!
 
             if (baseRoot == null)
             {
@@ -2084,7 +2084,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         {
             if (resolver == null) throw new ArgumentNullException(nameof(resolver));
 
-            return await isValidTypeProfile(resolver, new HashSet<string>(), type, profile);
+            return await isValidTypeProfile(resolver, new HashSet<string>(), type, profile).ConfigureAwait(false);
         }
 
         private static async T.Task<bool> isValidTypeProfile(IAsyncResourceResolver resolver, HashSet<string> recursionStack, string type, StructureDefinition profile)
@@ -2097,7 +2097,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             if (sdType == type) { return true; }
             if (profile.BaseDefinition == null) { return false; }
-            var sdBase = await resolver.FindStructureDefinitionAsync(profile.BaseDefinition);
+            var sdBase = await resolver.FindStructureDefinitionAsync(profile.BaseDefinition).ConfigureAwait(false);
             if (sdBase == null) { return false; }
             if (sdBase.Url == null) { return false; } // Shouldn't happen...
 
@@ -2109,7 +2109,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 );
             }
 
-            return await isValidTypeProfile(resolver, recursionStack, type, sdBase);
+            return await isValidTypeProfile(resolver, recursionStack, type, sdBase).ConfigureAwait(false);
         }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/ResourceResolverExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ResourceResolverExtensions.cs
@@ -38,7 +38,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <returns>Returns a StructureDefinition if it is resolvable and defines an extension, otherwise <c>null</c>.</returns>
         public static async T.Task<StructureDefinition> FindExtensionDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
         {
-            if (!(await resolver.ResolveByCanonicalUriAsync(uri) is StructureDefinition sd)) return null;
+            if (!(await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) is StructureDefinition sd)) return null;
 
             if (!sd.IsExtension)
                 throw Error.Argument(nameof(uri), $"Found StructureDefinition at '{uri}', but is not an extension");
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Specification.Source
         /// </summary>
         /// <returns>The resolved StructureDefinition or <c>null</c> if it cannot be resolved or does not resolve to a StructureDefinition.</returns>
         public static async T.Task<StructureDefinition> FindStructureDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
-            => await resolver.ResolveByCanonicalUriAsync(uri) as StructureDefinition;
+            => await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as StructureDefinition;
 
         /// <inheritdoc cref="FindStructureDefinitionForCoreTypeAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindStructureDefinitionForCoreTypeAsync() instead.")]
@@ -77,7 +77,7 @@ namespace Hl7.Fhir.Specification.Source
         public static async T.Task<StructureDefinition> FindStructureDefinitionForCoreTypeAsync(this IAsyncResourceResolver resolver, string typename)
         {
             var url = Uri.IsWellFormedUriString(typename, UriKind.Absolute) ? typename : ModelInfo.CanonicalUriForFhirCoreType(typename);
-            return await resolver.FindStructureDefinitionAsync(url);
+            return await resolver.FindStructureDefinitionAsync(url).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="FindStructureDefinitionForCoreTypeAsync(IAsyncResourceResolver, FHIRAllTypes)"/>
@@ -91,7 +91,7 @@ namespace Hl7.Fhir.Specification.Source
         /// Resolve the StructureDefinition for the FHIR-defined type given in <paramref name="type"/>.
         /// </summary>
         public static async T.Task<StructureDefinition> FindStructureDefinitionForCoreTypeAsync(this IAsyncResourceResolver resolver, FHIRAllTypes type)
-            => await resolver.FindStructureDefinitionForCoreTypeAsync(ModelInfo.FhirTypeToFhirTypeName(type));
+            => await resolver.FindStructureDefinitionForCoreTypeAsync(ModelInfo.FhirTypeToFhirTypeName(type)).ConfigureAwait(false);
 
         /// <inheritdoc cref="FindValueSetAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindValueSetAsync() instead.")]
@@ -102,7 +102,7 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a ValueSet by canonical url.
         /// </summary>
         public static async T.Task<ValueSet> FindValueSetAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri) as ValueSet;
+            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as ValueSet;
 
         /// <inheritdoc cref="FindCodeSystemAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindCodeSystemAsync() instead.")]
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a CodeSystem by canonical url.
         /// </summary>
         public static async T.Task<CodeSystem> FindCodeSystemAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri) as CodeSystem;
+            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as CodeSystem;
 
         public static IEnumerable<T> FindAll<T>(this IConformanceSource source) where T : Resource
         {

--- a/src/Hl7.Fhir.Specification/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/SnapshotSource.cs
@@ -68,7 +68,7 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
-        public async T.Task<Resource> ResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByUriAsync(uri));
+        public async T.Task<Resource> ResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
@@ -76,7 +76,7 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
-        public async T.Task<Resource> ResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByCanonicalUriAsync(uri));
+        public async T.Task<Resource> ResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
@@ -92,7 +92,7 @@ namespace Hl7.Fhir.Specification.Source
             {
                 if (!sd.HasSnapshot || Generator.Settings.ForceRegenerateSnapshots || !sd.Snapshot.IsCreatedBySnapshotGenerator())
                 {
-                    await Generator.UpdateAsync(sd);
+                    await Generator.UpdateAsync(sd).ConfigureAwait(false);
                 }
             }
             return res;

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -61,7 +61,8 @@ namespace Hl7.Fhir.Specification
 
         [Obsolete("StructureDefinitionSummaryProvider now works best with asynchronous resolvers. Use ProvideAsync() instead.")]
         public IStructureDefinitionSummary Provide(string canonical) =>
-            TaskHelper.Await(() => ProvideAsync(canonical));
+            //TaskHelper.Await(() => ProvideAsync(canonical));
+            ProvideAsync(canonical).GetAwaiter().GetResult();
     }
 
     internal struct BackboneElementComplexTypeSerializationInfo : IStructureDefinitionSummary

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -52,7 +52,7 @@ namespace Hl7.Fhir.Specification
                 if (!mapSuccess) return null;
             }
 
-            var sd = await _resolver.FindStructureDefinitionAsync(mappedCanonical);
+            var sd = await _resolver.FindStructureDefinitionAsync(mappedCanonical).ConfigureAwait(false);
             
             return sd is null ? 
                 null 

--- a/src/Hl7.Fhir.Specification/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Terminology/ValueSetExpander.cs
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
             try
             {
-                await handleCompose(source);
+                await handleCompose(source).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -60,8 +60,8 @@ namespace Hl7.Fhir.Specification.Terminology
             if (source.Compose == null) return;
 
             // handleImport(source);
-            await handleInclude(source);
-            await handleExclude(source);
+            await handleInclude(source).ConfigureAwait(false);
+            await handleExclude(source).ConfigureAwait(false);
         }
 
 
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 else
                 {
                     // Do a full import of the codesystem
-                    var importedConcepts = await getConceptsFromCodeSystem(conceptSet.System);
+                    var importedConcepts = await getConceptsFromCodeSystem(conceptSet.System).ConfigureAwait(false);
                     import(result, importedConcepts, conceptSet.System);
                 }
             }
@@ -102,7 +102,7 @@ namespace Hl7.Fhir.Specification.Terminology
                     throw new ValueSetExpansionTooComplexException($"ConceptSets with combined 'system' and 'valueset'(s) are not yet supported.");
 
                 var importedVs = conceptSet.ValueSet.Single();
-                var concepts = await getExpansionForValueSet(importedVs);
+                var concepts = await getExpansionForValueSet(importedVs).ConfigureAwait(false);
                 import(result, concepts, importedVs);
             }
             
@@ -124,7 +124,7 @@ namespace Hl7.Fhir.Specification.Terminology
             int csIndex = 0;
             foreach (var include in source.Compose.Include)
             {
-                var includedConcepts = await collectConcepts(include);
+                var includedConcepts = await collectConcepts(include).ConfigureAwait(false);
 
                 // Yes, exclusion could make this smaller again, but alas, before we have processed those we might have run out of memory
                 if (source.Expansion.Total + includedConcepts.Count > Settings.MaxExpansionSize)
@@ -145,7 +145,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
             foreach (var exclude in source.Compose.Exclude)
             {
-                var excludedConcepts = await collectConcepts(exclude);
+                var excludedConcepts = await collectConcepts(exclude).ConfigureAwait(false);
 
                 source.Expansion.Contains.Remove(excludedConcepts);
 
@@ -161,10 +161,10 @@ namespace Hl7.Fhir.Specification.Terminology
                 throw Error.InvalidOperation($"No valueset resolver available to resolve valueset '{uri}', " +
                         "set ValueSetExpander.Settings.ValueSetSource to fix.");
 
-            var importedVs = await Settings.ValueSetSource.AsAsync().FindValueSetAsync(uri);
+            var importedVs = await Settings.ValueSetSource.AsAsync().FindValueSetAsync(uri).ConfigureAwait(false);
             if (importedVs == null) throw new ValueSetUnknownException($"Cannot resolve canonical reference '{uri}' to ValueSet");
 
-            if (!importedVs.HasExpansion) await ExpandAsync(importedVs);
+            if (!importedVs.HasExpansion) await ExpandAsync(importedVs).ConfigureAwait(false);
 
             if (importedVs.HasExpansion)
                 return importedVs.Expansion.Contains;
@@ -178,7 +178,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 throw Error.InvalidOperation($"No terminology service available to resolve references to codesystem '{uri}', " +
                         "set ValueSetExpander.Settings.ValueSetSource to fix.");
 
-            var importedCs = await Settings.ValueSetSource.AsAsync().FindCodeSystemAsync(uri);
+            var importedCs = await Settings.ValueSetSource.AsAsync().FindCodeSystemAsync(uri).ConfigureAwait(false);
             if (importedCs == null) throw new ValueSetUnknownException($"Cannot resolve canonical reference '{uri}' to CodeSystem");
 
             var result = new List<ValueSet.ContainsComponent>();


### PR DESCRIPTION
* Add ConfigureAwait(false) where applicable
* Fix the SDSummaryProvider.Provide() call to just block instead of using Task.Run() -> fixes performance problems for now (until we have replaced the SDSummaryProvider with natively async stuff)
