### PR TITLE
fix: removed LastReponse and LastRequest from FhirClient and LegacyFhirClient

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -42,14 +42,6 @@ namespace Hl7.Fhir.Rest
         public string LastBodyAsText => LastResult?.GetBodyAsText();
         public Resource LastBodyAsResource { get; private set; }
 
-        //This is an object because of the different libraries we use for the client.
-        //This can either be a HttpWebRequest (FhirClient) or a HttpRequestMessage(FhirHttpClient)
-        protected object LastClientRequest { get; set; }
-
-        //This is an object because of the different libraries we use for the client.
-        //This can either be a HttpWebResponse (FhirClient) or a HttpResponseMessage(FhirHttpClient)
-        protected object LastClientResponse { get; set; }
-
         private static Uri getValidatedEndpoint(Uri endpoint)
         {
             if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
@@ -918,8 +910,6 @@ namespace Hl7.Fhir.Rest
             try
             {
                 response = typedEntryResponse.ToBundleEntry(Settings.ParserSettings);
-                LastClientRequest = typedEntryResponse.LastRequest;
-                LastClientResponse = typedEntryResponse.LastResponse;
                 
                 LastResult = response.Response;
                 LastBodyAsResource = response.Resource;

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -19,6 +19,9 @@ namespace Hl7.Fhir.Rest
 {
     public partial class FhirClient : BaseFhirClient
     {
+//disables warning that OnBeforeRequest and OnAfterResponse are never used.
+#pragma warning disable CS0067
+        
         /// <summary>
         /// Creates a new client using a default endpoint
         /// If the endpoint does not end with a slash (/), it will be added.
@@ -67,17 +70,6 @@ namespace Hl7.Fhir.Rest
         /// </summary>
         public HttpRequestHeaders RequestHeaders { get; protected set; }
 
-        /// <summary>
-        /// Returns the HttpRequestMessage as it was last constructed to execute a call on the FhirClient
-        /// </summary>
-        public HttpRequestMessage LastRequestMessage { get { return (Requester as HttpClientRequester)?.LastRequest; } }
-
-        /// <summary>
-        /// Returns the HttpResponseMessage as it was last received during a call on the FhirClient
-        /// </summary>
-        /// <remarks>Note that the FhirClient will have read the body data from the HttpResponseMessage, so this is
-        /// no longer available. Use LastBody, LastBodyAsText and LastBodyAsResource to get access to the received body (if any)</remarks>
-        public HttpResponseMessage LastResponseMessage { get { return (Requester as HttpClientRequester)?.LastResponse; } }
 
         #region << Client Communication Defaults (PreferredFormat, UseFormatParam, Timeout, ReturnFullResource) >>
         [Obsolete("Use the FhirClient.Settings property or the settings argument in the constructor instead")]
@@ -153,7 +145,6 @@ namespace Hl7.Fhir.Rest
             set => Settings.PreferredParameterHandling = value;
         }
 
-
         /// <summary>
         /// This will do 2 things:
         /// 1. Add the header Accept-Encoding: gzip, deflate
@@ -182,25 +173,12 @@ namespace Hl7.Fhir.Rest
             get => Settings.ParserSettings;
             set => Settings.ParserSettings = value;
         }
-
-        /// <summary>
-        /// Returns the HttpWebRequest as it was last constructed to execute a call on the FhirClient
-        /// </summary>
-        public HttpWebRequest LastRequest { get { return LastClientRequest as HttpWebRequest; } }
-
-        /// <summary>
-        /// Returns the HttpWebResponse as it was last received during a call on the FhirClient
-        /// </summary>
-        /// <remarks>Note that the FhirClient will have read the body data from the HttpWebResponse, so this is
-        /// no longer available. Use LastBody, LastBodyAsText and LastBodyAsResource to get access to the received body (if any)</remarks>
-        public HttpWebResponse LastResponse { get { return LastClientResponse as HttpWebResponse; } }
-
         #endregion
 
-        [Obsolete ("OnBeforeRequest is deprecated, please add a HttpClientEventHandler to the constructor to use this functionality", true)]
+        [Obsolete ("OnBeforeRequest is deprecated, please add a HttpClientEventHandler or another HttpMessageHandler to the constructor to use this functionality", true)]
         public event EventHandler<BeforeHttpRequestEventArgs> OnBeforeRequest;
 
-        [Obsolete("OnAfterResponse is deprecated, please add a HttpClientEventHandler to the constructor to use this functionality", true)]
+        [Obsolete("OnAfterResponse is deprecated, please add a HttpClientEventHandler or another HttpMessageHandler to the constructor to use this functionality", true)]
         public event EventHandler<BeforeHttpRequestEventArgs> OnAfterResponseRequest;
 
 

--- a/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
@@ -144,7 +144,6 @@ namespace Hl7.Fhir.Rest.Legacy
             get => Settings.PreferredParameterHandling;
             set => Settings.PreferredParameterHandling = value;
         }
-
         
         /// <summary>
         /// This will do 2 things:
@@ -174,18 +173,21 @@ namespace Hl7.Fhir.Rest.Legacy
             get => Settings.ParserSettings;
             set => Settings.ParserSettings = value;
         }
-        
+
         /// <summary>
         /// Returns the HttpWebRequest as it was last constructed to execute a call on the FhirClient
         /// </summary>
-        public HttpWebRequest LastRequest { get { return LastClientRequest as HttpWebRequest; } }
+        /// 
+        [Obsolete("LastRequest was already disposed, so no point in having them around", true)]
+        public HttpWebRequest LastRequest;
 
         /// <summary>
         /// Returns the HttpWebResponse as it was last received during a call on the FhirClient
         /// </summary>
         /// <remarks>Note that the FhirClient will have read the body data from the HttpWebResponse, so this is
         /// no longer available. Use LastBody, LastBodyAsText and LastBodyAsResource to get access to the received body (if any)</remarks>
-        public HttpWebResponse LastResponse { get { return LastClientResponse as HttpWebResponse; } }
+        [Obsolete("LastResponse was already disposed, so no point in having them around", true)]
+        public HttpWebResponse LastResponse;
         
         #endregion
         


### PR DESCRIPTION
fixes #1132

Removed LastResponse and LastRequest from the FhirClient(s). They were already disposed, so no point having them around.