### PR TITLE
fix: snapshot generator: ignore invalid sliceName error on SimpleQuantity root

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -3194,12 +3194,9 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(nav.Current.Type.FirstOrDefault().Code, FHIRAllTypes.Integer.GetLiteral());
 
             Assert.IsNotNull(outcome);
-            // [WMR 20170810] Fixed, now also expecting issue about invalid slice name on SimpleQuantity root element
-            //Assert.AreEqual(1, outcome.Issue.Count);
-            // assertIssue(outcome.Issue[0], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_CHOICE_CONSTRAINT);
-            Assert.AreEqual(2, outcome.Issue.Count);
-            assertIssue(outcome.Issue[0], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_SLICENAME_ON_ROOT);
-            assertIssue(outcome.Issue[1], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_CHOICE_CONSTRAINT);
+
+            Assert.AreEqual(1, outcome.Issue.Count);
+            assertIssue(outcome.Issue[0], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_CHOICE_CONSTRAINT);
         }
 
         static StructureDefinition ClosedExtensionSliceObservationProfile => new StructureDefinition()
@@ -5688,10 +5685,11 @@ namespace Hl7.Fhir.Specification.Tests
             dumpElements(elems);
             // dumpBaseElems(elems);
 
+            var issues = _generator.Outcome?.Issue.Where(i => i.Details.Coding.FirstOrDefault().Code == SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE.Code.ToString());
+
             // Verify there is NO warning about invalid element type constraint
-            Assert.IsFalse(_generator.Outcome.Issue.Any(
-                i => i.Details.Coding.FirstOrDefault().Code == SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE.Code.ToString())
-            );
+            Assert.IsTrue(issues == null || !issues.Any());
+            
         }
 
         // [WMR 20170925] BUG: Stefan Lang - Forge displays both valueString and value[x]
@@ -6863,11 +6861,8 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(expanded);
             Assert.IsTrue(expanded.HasSnapshot);
 
-            // Expecting single issue about invalid slice name on SimpleQuantity root element
             var outcome = generator.Outcome;
-            //Assert.IsNull(outcome);
-            Assert.AreEqual(1, outcome.Issue.Count);
-            assertIssue(outcome.Issue[0], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_SLICENAME_ON_ROOT);
+            Assert.IsNull(outcome);       
 
             var nav = ElementDefinitionNavigator.ForSnapshot(expanded);
             Assert.IsNotNull(nav);

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -4449,6 +4449,16 @@ namespace Hl7.Fhir.Specification.Tests
             expanded.Snapshot.Element.Where(e => e.Path.StartsWith("Observation.value")).Dump();
             dumpOutcome(_generator.Outcome);
 
+            var issues = _generator.Outcome?.Issue;
+            Assert.IsNull(issues);
+
+            // [WMR 20180115] NEW - Use alternative (iterative) approach for full expansion
+            issues = new List<OperationOutcome.IssueComponent>();
+            var elems = expanded.Snapshot.Element;
+            elems = expanded.Snapshot.Element = fullyExpand(elems, issues).ToList();
+            // Generator should report same issue as during regular snapshot expansion
+            Assert.AreEqual(0, issues.Count);
+
             // Ensure that renamed diff elements override base elements with original names
             var nav = ElementDefinitionNavigator.ForSnapshot(expanded);
             // Snapshot should not contain elements with original name

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -4477,7 +4477,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void TestSimpleQuantity()
         {
-            var resource = _testResolver.FindStructureDefinition("http://hl7.org/fhir/StructureDefinition/SimpleQuantity");
+            var resource = _testResolver.FindStructureDefinition(ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.SimpleQuantity));
             _generator = new SnapshotGenerator(_testResolver);
             var snapshot = _generator.Generate(resource);
             Assert.IsNotNull(snapshot);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1079,6 +1079,22 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.Equal(nrOfParrallelTasks, successes);
         }
 
+        [Fact]
+        public void testSimpleQuantityForInvalidSliceOnRoot()
+        {
+            var sq = new SimpleQuantity
+            {
+                Code = "m",
+                Value = 1,
+                System = "http://unitsofmeasure.org"
+            };
+
+            var sqSd = _source.FindStructureDefinitionForCoreType(FHIRAllTypes.SimpleQuantity);
+            sqSd.Snapshot = null;
+            var result = _validator.Validate(sq, sqSd);
+            Assert.True(result.Success);
+        }
+
         /// <summary>
         /// This test should show that the rng-2 constraint is totally ignored (it's
         /// incorrect in DSTU2 and STU3), but others are not.
@@ -1173,6 +1189,8 @@ namespace Hl7.Fhir.Specification.Tests
                 }
             }
         }
+
+      
 
         private class ClearSnapshotResolver : IResourceResolver
         {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -436,7 +436,10 @@ namespace Hl7.Fhir.Specification.Snapshot
                 Debug.Assert(elem.IsRootElement());
                 if (!string.IsNullOrEmpty(elem.SliceName))
                 {
-                    addIssueInvalidSliceNameOnRootElement(elem, sd);
+                    if(sd.Url != ModelInfo.FhirCoreProfileBaseUri + ModelInfo.FhirTypeToFhirTypeName(FHIRAllTypes.SimpleQuantity))
+                    {
+                        addIssueInvalidSliceNameOnRootElement(elem, sd);
+                    }                        
                     elem.SliceName = null;
                 }
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -436,7 +436,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 Debug.Assert(elem.IsRootElement());
                 if (!string.IsNullOrEmpty(elem.SliceName))
                 {
-                    if(sd.Url != ModelInfo.FhirCoreProfileBaseUri + ModelInfo.FhirTypeToFhirTypeName(FHIRAllTypes.SimpleQuantity))
+                    if (sd.Url != ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.SimpleQuantity))
                     {
                         addIssueInvalidSliceNameOnRootElement(elem, sd);
                     }                        


### PR DESCRIPTION
Fixes #618

Ignores invalid slicename error on SImpleQuantity root.