### PR TITLE
fix: #884 %resource confusion (for R3)

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/FhirEvaluationContext.cs
@@ -23,11 +23,18 @@ namespace Hl7.Fhir.FhirPath
         {
         }
 
-        public FhirEvaluationContext(Resource context) : base(context?.ToTypedElement())
+        /// <inheritdoc cref="EvaluationContext.EvaluationContext(ITypedElement)"/>
+        public FhirEvaluationContext(Resource resource) : base(resource?.ToTypedElement())
         {
         }
 
-        public FhirEvaluationContext(ITypedElement context) : base(context)
+        /// <inheritdoc cref="EvaluationContext.EvaluationContext(ITypedElement)"/>
+        public FhirEvaluationContext(ITypedElement resource) : base(resource)
+        {
+        }
+
+        /// <inheritdoc cref="EvaluationContext.EvaluationContext(ITypedElement, ITypedElement)"/>
+        public FhirEvaluationContext(ITypedElement resource, ITypedElement rootResource) : base(resource, rootResource)
         {
         }
 

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -32,7 +32,15 @@ namespace Hl7.Fhir.Validation
             if (!definition.Constraint.Any()) return outcome;
             if (v.Settings.SkipConstraintValidation) return outcome;
 
-            var context = instance.ResourceContext;
+            // Determine %resource: if the current instance is a resource, %resource is simply
+            // a pointer to the current data. If the data is a datatype, %resource is the parent resource
+            // the datatype is part of.
+            var resource = instance.AtResource ? instance : instance.ResourceContext;
+
+            // Determine %rootResource: this is the parent of the current %resource, not being the
+            // container bundle. So, this only differs from %resource, when %resource is a contained resource
+            // within a DomainResource
+            var rootResource = resource is ScopedNode sn ? sn.ResourceContext : resource;
 
             foreach (var constraintElement in definition.Constraint)
             {
@@ -46,7 +54,9 @@ namespace Hl7.Fhir.Validation
                 try
                 {
                     var compiled = getExecutableConstraint(v, outcome, instance, constraintElement);
-                    success = compiled.Predicate(instance, new FhirEvaluationContext(context) { ElementResolver = callExternalResolver } );
+                    success = compiled.Predicate(instance, 
+                        new FhirEvaluationContext(resource: resource, rootResource: rootResource)
+                        { ElementResolver = callExternalResolver } );
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
The differences between %context, %resource and %rootResource were not clear - added comments to the properties representing them, even renamed some. Then made sure validator passed in the right values to these FhirPath variables.