### PR TITLE
Refactor R5: use of extension structuredefinition-interface

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -2651,7 +2651,7 @@ namespace Hl7.Fhir.Specification.Tests
             if (!result)
             {
                 Debug.Print("Expanded is not exactly equal to original... verifying...");
-                result = verifyElementBase(sd, expanded);
+                result = await verifyElementBase(sd, expanded);
             }
 
             // Core artifact snapshots are incorrect, e.g. url snapshot is missing extension element
@@ -2739,7 +2739,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Verify ElementDefinition.Base components
-        bool verifyElementBase(StructureDefinition original, StructureDefinition expanded)
+        async T.Task<bool> verifyElementBase(StructureDefinition original, StructureDefinition expanded)
         {
             var originalElems = original.HasSnapshot ? original.Snapshot.Element : new List<ElementDefinition>();
             var expandedElems = expanded.HasSnapshot ? expanded.Snapshot.Element : new List<ElementDefinition>();
@@ -2800,9 +2800,9 @@ namespace Hl7.Fhir.Specification.Tests
                 else if (expanded.Kind == StructureDefinition.StructureDefinitionKind.Resource)
                 {
                     // [WMR 20190131] Fixed
-                    var baseDef = SnapshotGenerator.getBaseDefinition(expanded);
-                    bool isDerivedFromResource = baseDef == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Resource);
-                    bool isDerivedFromDomainResource = baseDef == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource);
+                    var baseDef = await _generator.getBaseDefinition(expanded);
+                    bool isDerivedFromResource = baseDef?.BaseDefinition == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Resource);
+                    bool isDerivedFromDomainResource = baseDef?.BaseDefinition == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource);
                     bool isDomainResource = expanded.Name == "DomainResource";
 
                     // [WMR 20190130] STU3

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -2801,8 +2801,8 @@ namespace Hl7.Fhir.Specification.Tests
                 {
                     // [WMR 20190131] Fixed
                     var baseDef = await _generator.getBaseDefinition(expanded);
-                    bool isDerivedFromResource = baseDef?.BaseDefinition == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Resource);
-                    bool isDerivedFromDomainResource = baseDef?.BaseDefinition == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource);
+                    bool isDerivedFromResource = baseDef?.Url == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Resource);
+                    bool isDerivedFromDomainResource = baseDef?.Url == ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DomainResource);
                     bool isDomainResource = expanded.Name == "DomainResource";
 
                     // [WMR 20190130] STU3

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -301,6 +301,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <returns>The parent of <paramref name="structure"/>, skipping the interface classes</returns>
         internal async T.Task<StructureDefinition> getBaseDefinition(StructureDefinition structure)
         {
+            structure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition);
             while (structure?.GetBoolExtension(SnapshotGeneratorExtensions.STRUCTURE_DEFINITION_INTERFACE_EXT) == true)
             {
                 structure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition);

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -25,6 +25,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <summary>The canonical url of the extension definition that marks snapshot elements with associated differential constraints.</summary>
         // public static readonly string CHANGED_BY_DIFF_EXT = "http://hl7.org/fhir/StructureDefinition/changedByDifferential";
         public static readonly string CONSTRAINED_BY_DIFF_EXT = "http://hl7.org/fhir/StructureDefinition/constrainedByDifferentialExtension";
+        public static readonly string STRUCTURE_DEFINITION_INTERFACE_EXT = "http://hl7.org/fhir/StructureDefinition/structuredefinition-interface";
 
         /// <summary>
         /// Decorate the specified snapshot element definition with a special extension


### PR DESCRIPTION
We use now the `extension structuredefinition-interface` to identify the pattern/interface classes `CanonicalResource` and `MetadataResource`