### PR TITLE
Function as(type) to the fhirpath simple collection

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
@@ -67,6 +67,10 @@ namespace Hl7.Fhir.Specification.Tests
             // Try walking into an 'any' choice
             elem = walker.Walk("method.extension.value.ofType(HumanName).family").Single();
             Assert.AreEqual("HumanName.family", elem.Current.Path);
+
+            // use the backwards compatible function 'as()'
+            elem = walker.Walk("value.as(Quantity).system").Single();
+            Assert.AreEqual("Quantity.system", elem.Current.Path);
         }
 
         [TestMethod]
@@ -139,6 +143,8 @@ namespace Hl7.Fhir.Specification.Tests
             eval("active.slice()");
             eval("active.ofType()");
             eval("active.OfType('something')");
+            eval("active.as()");
+            eval("active.As('something')");
             eval("active.where(true)");
 
             void eval(string expr)

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
@@ -50,10 +50,11 @@ namespace Hl7.Fhir.Specification.Navigation
                 case "extension":
                     var url = getSingleStringParameter(call);
                     return parentSet.Extension(url);
+                case "as": // 'as()' for backwards compatibility only
                 case "ofType":
                     var type = getSingleStringParameter(call);
                     if (!ModelInfo.IsCoreModelType(type))
-                        throw new DiscriminatorFormatException($"Type '{type}' passed to ofType() is not a known FHIR type.");
+                        throw new DiscriminatorFormatException($"Type '{type}' passed to {call.FunctionName}() is not a known FHIR type.");
                     return parentSet.OfType(type);
                 default:
                     throw new DiscriminatorFormatException($"Invocation of function '{call.FunctionName}' is not supported in discriminators.");


### PR DESCRIPTION
Fixes #1473 

Adding the function `as(type)` to the fhirpath simple, which is used in `ElementDefinition.slicing.discriminator.path`
