### PR TITLE
Correct IsInstanceTypeFor() in ModelInfo (R3)

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -371,6 +371,31 @@ namespace Hl7.Fhir.Tests.Model
         }
 
         [TestMethod]
+        public void TestSubclassInfoByType()
+        {
+            testTrue(typeof(Resource), typeof(Patient));
+            testTrue(typeof(DomainResource), typeof(Patient));
+            testTrue(typeof(Patient), typeof(Patient));
+            testFalse(typeof(Observation), typeof(Patient));
+            testFalse(typeof(Element), typeof(Patient));
+            testTrue(typeof(Resource), typeof(Bundle));
+            testFalse(typeof(DomainResource), typeof(Bundle));
+
+            testTrue(typeof(Element), typeof(HumanName));
+            testFalse(typeof(Element), typeof(Patient));
+            testTrue(typeof(Element), typeof(Oid));
+            testFalse(typeof(FhirString), typeof(Markdown));
+            testFalse(typeof(Integer), typeof(UnsignedInt));
+
+            static void testTrue(Type super, Type sub) =>
+                Assert.IsTrue(ModelInfo.IsInstanceTypeFor(super, sub));
+
+            static void testFalse(Type super, Type sub) =>
+                Assert.IsFalse(ModelInfo.IsInstanceTypeFor(super, sub));
+        }
+
+
+        [TestMethod]
         public void TestIntegerValueInterface()
         {
             INullableValue<int> iv = new Integer(null);

--- a/src/Hl7.Fhir.Core/Model/ModelInfo.cs
+++ b/src/Hl7.Fhir.Core/Model/ModelInfo.cs
@@ -427,18 +427,22 @@ namespace Hl7.Fhir.Model
 
         public static bool IsInstanceTypeFor(string superclass, string subclass)
         {
-            var superType = FhirTypeNameToFhirType(superclass);
-            var subType = FhirTypeNameToFhirType(subclass);
+            if (superclass == subclass) return true;
+
+            var superType = GetTypeForFhirType(superclass);
+            var subType = GetTypeForFhirType(subclass);
 
             if (subType == null || superType == null) return false;
 
-            return IsInstanceTypeFor(superType.Value, subType.Value);
+            return IsInstanceTypeFor(superType, subType);
         }
 
-        private static readonly FHIRAllTypes[] QUANTITY_SUBCLASSES = new[] { FHIRAllTypes.Age, FHIRAllTypes.Distance, FHIRAllTypes.Duration,
-                            FHIRAllTypes.Count, FHIRAllTypes.Money };
-        private static readonly FHIRAllTypes[] STRING_SUBCLASSES = new[] { FHIRAllTypes.Code, FHIRAllTypes.Id, FHIRAllTypes.Markdown };
-        private static readonly FHIRAllTypes[] INTEGER_SUBCLASSES = new[] { FHIRAllTypes.UnsignedInt, FHIRAllTypes.PositiveInt };
+        public static bool IsInstanceTypeFor(Type superclass, Type subclass)
+        {
+            if (superclass == subclass) return true;
+
+            return superclass.IsAssignableFrom(subclass);
+        }
 
         public static bool IsInstanceTypeFor(FHIRAllTypes superclass, FHIRAllTypes subclass)
         {
@@ -455,16 +459,7 @@ namespace Hl7.Fhir.Model
             }
             else
             {
-                if (superclass == FHIRAllTypes.Element)
-                    return true;
-                else if (superclass == FHIRAllTypes.Quantity)
-                    return QUANTITY_SUBCLASSES.Contains(subclass);
-                else if (superclass == FHIRAllTypes.String)
-                    return STRING_SUBCLASSES.Contains(subclass);
-                else if (superclass == FHIRAllTypes.Integer)
-                    return INTEGER_SUBCLASSES.Contains(subclass);
-                else
-                    return false;
+                return superclass == FHIRAllTypes.Element;
             }
         }
 


### PR DESCRIPTION
IsInstanceTypeFor() was far to flexible, allowing e.g. `markdown` as an instance for `string`.  Although `markdown` is a variant of `string`, substitution is not allowed for these types. This PR corrects this mistake.
