### PR TITLE
feature: Add script to quickly set TargetFramework on all csproj files

### DIFF
--- a/build/ChangeTargetFramework.ps1
+++ b/build/ChangeTargetFramework.ps1
@@ -1,0 +1,31 @@
+﻿Param(
+  [string]$TFparam
+)
+
+$newTF = "netstandard2.0;net45;netstandard1.6"
+
+If (![string]::IsNullOrEmpty($TFparam)) 
+{
+	$newTF = $TFparam
+}
+
+$projectFiles = Get-Childitem .. -Recurse -Include *.csproj
+
+foreach($currentProjFile in $projectFiles)
+{
+  $isTest = $currentProjFile.Name.Contains(".Tests.csproj")  
+
+  # test files are untouched - they are just using only one platform anyway
+  if($isTest) { continue }
+
+  Write "Updating target frameworks for $currentProjFile to: $newTF"
+
+  $xml = [xml](get-content $currentProjFile) 
+
+  if($xml.Project.PropertyGroup[0].TargetFrameworks)
+  {
+    $xml.Project.PropertyGroup[0].TargetFrameworks = $newTF
+  }
+  
+  $xml.Save($currentProjFile)  
+}

--- a/build/ChangeTargetFramework.ps1
+++ b/build/ChangeTargetFramework.ps1
@@ -1,31 +1,26 @@
-﻿Param(
-  [string]$TFparam
+﻿# This script takes a single parameter, the (possible) concatenated list of platforms to build against.
+# There is a sensible default, so it will run without a param as well.
+
+Param(
+  [string]$newTF = "netstandard2.0;net45;netstandard1.6"
 )
 
-$newTF = "netstandard2.0;net45;netstandard1.6"
-
-If (![string]::IsNullOrEmpty($TFparam)) 
-{
-	$newTF = $TFparam
-}
-
-$projectFiles = Get-Childitem .. -Recurse -Include *.csproj
+# Scan for all project files in the /src directory, but exclude test projects
+$projectFiles =  Get-Childitem .. -Recurse -Include *.csproj -Exclude *.Tests.csproj
 
 foreach($currentProjFile in $projectFiles)
 {
-  $isTest = $currentProjFile.Name.Contains(".Tests.csproj")  
-
-  # test files are untouched - they are just using only one platform anyway
-  if($isTest) { continue }
-
   Write "Updating target frameworks for $currentProjFile to: $newTF"
 
+  # read the XML for the project file
   $xml = [xml](get-content $currentProjFile) 
 
+  # If the project specifies a target framework, overwrite it with the new one
   if($xml.Project.PropertyGroup[0].TargetFrameworks)
   {
     $xml.Project.PropertyGroup[0].TargetFrameworks = $newTF
   }
-  
+
+  # save the xml back to the original project file  
   $xml.Save($currentProjFile)  
 }


### PR DESCRIPTION
Finds all non-test project files and changes the target framework to a given framework (or frameworks).

This allows individual team members to speed up their build/debug cycle while working in a new feature, by disabling support for all frameworks. The CI build will of course check and build against all supported frameworks.
