### PR TITLE
fixed: not changing the static issue TERMINOLOGY_SERVICE_FAILED, but …

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Terminology/OperationValidCodeExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Terminology/OperationValidCodeExtensions.cs
@@ -21,9 +21,8 @@ namespace Hl7.Fhir.Specification.Terminology
             var outcome = new OperationOutcome();
             if (message is { })
             {
-                var issue = Issue.TERMINOLOGY_SERVICE_FAILED;
-                issue.Severity = result ? OperationOutcome.IssueSeverity.Warning : OperationOutcome.IssueSeverity.Error;
-                outcome.AddIssue(message, issue);
+                var severity = result ? OperationOutcome.IssueSeverity.Warning : OperationOutcome.IssueSeverity.Error;
+                outcome.Add(OperationOutcome.ForMessage(message, OperationOutcome.IssueType.NotSupported, severity));
             }
             return outcome;
         }


### PR DESCRIPTION
This fix has been already fixed at r5, because of unit test failures. 
Changing an existing static Issue (`Issue.TERMINOLOGY_SERVICE_FAILED`) is not the way to go.
