### PR TITLE
fix: back to old enum style for STU3

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
@@ -158,7 +158,7 @@ namespace Hl7.Fhir.Model
       /// (system: http://hl7.org/fhir/map-source-list-mode)
       /// </summary>
       [EnumLiteral("not_first", "http://hl7.org/fhir/map-source-list-mode"), Description("All but the first")]
-      NotFirst,
+      Not_first,
       /// <summary>
       /// Only process this rule for the last in the list
       /// (system: http://hl7.org/fhir/map-source-list-mode)
@@ -170,13 +170,13 @@ namespace Hl7.Fhir.Model
       /// (system: http://hl7.org/fhir/map-source-list-mode)
       /// </summary>
       [EnumLiteral("not_last", "http://hl7.org/fhir/map-source-list-mode"), Description("All but the last")]
-      NotLast,
+      Not_last,
       /// <summary>
       /// Only process this rule is there is only item
       /// (system: http://hl7.org/fhir/map-source-list-mode)
       /// </summary>
       [EnumLiteral("only_one", "http://hl7.org/fhir/map-source-list-mode"), Description("Enforce only one")]
-      OnlyOne,
+      Only_one,
     }
 
     /// <summary>


### PR DESCRIPTION
Rollback the way of enum generating. This PR belongs to commit-id a678f25f9e2b25f00742b85da0b6ca3d0198c33d of microsoft/fhir-codegen